### PR TITLE
Fix not default attribute

### DIFF
--- a/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
+++ b/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="ExtendedValidatorTests.cs" />
     <Compile Include="MaxElementsIfAttributeTest.cs" />
     <Compile Include="MinElementsTests.cs" />
+    <Compile Include="NotDefaultTest.cs" />
     <Compile Include="NotEqualToAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegularExpressionIfAttributeTest.cs" />

--- a/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
+++ b/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
@@ -76,7 +76,7 @@
     <Compile Include="ExtendedValidatorTests.cs" />
     <Compile Include="MaxElementsIfAttributeTest.cs" />
     <Compile Include="MinElementsTests.cs" />
-    <Compile Include="NotDefaultTest.cs" />
+    <Compile Include="NotDefaultFixture.cs" />
     <Compile Include="NotEqualToAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegularExpressionIfAttributeTest.cs" />

--- a/HermaFx.DataAnnotations.Tests/NotDefaultFixture.cs
+++ b/HermaFx.DataAnnotations.Tests/NotDefaultFixture.cs
@@ -5,7 +5,7 @@ using System;
 namespace HermaFx.DataAnnotations
 {
 	[TestFixture]
-	public class NotDefaultTest
+	public class NotDefaultFixture
 	{
 		private class Model
 		{

--- a/HermaFx.DataAnnotations.Tests/NotDefaultFixture.cs
+++ b/HermaFx.DataAnnotations.Tests/NotDefaultFixture.cs
@@ -14,25 +14,217 @@ namespace HermaFx.DataAnnotations
 		}
 
 		[Test]
-		public void IsValid()
-		{
-			var model = new Model() { Value = Guid.NewGuid() };
-			ExtendedValidator.EnsureIsValid(model);
-		}
-
-		[Test]
-		public void IsNotValid()
-		{
-			var model = new Model() { Value = default(Guid) };
-			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
-		}
-
-		[Test]
 		public void IsNotValidWithNulls()
 		{
 			var model = new Model() { };
 			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
 		}
 
+		#region Guid
+
+		private class GuidModel
+		{
+			[NotDefault]
+			public Guid Value { get; set; }
+		}
+
+		[Test]
+		public void GuidIsValid()
+		{
+			var model = new GuidModel() { Value = Guid.NewGuid() };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void GuidIsNotValid()
+		{
+			var model = new GuidModel() { Value = default(Guid) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		// GUID?
+		private class GuidNulableModel
+		{
+			[NotDefault]
+			public Guid? Value { get; set; }
+		}
+
+		[Test]
+		public void GuidNulableIsValid()
+		{
+			var model = new GuidNulableModel() { Value = Guid.NewGuid() };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
+
+		#region int
+
+		private class IntModel
+		{
+			[NotDefault]
+			public int Value { get; set; }
+		}
+
+		[Test]
+		public void IntIsValid()
+		{
+			var model = new IntModel() { Value = 5 };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void IntIsNotValid()
+		{
+			var model = new IntModel() { Value = default(int) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		// int?
+		private class IntNulableModel
+		{
+			[NotDefault]
+			public int? Value { get; set; }
+		}
+
+		[Test]
+		public void IntNulableIsValid()
+		{
+			var model = new IntNulableModel() { Value = 5 };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
+
+		#region short
+
+		private class ShortModel
+		{
+			[NotDefault]
+			public short Value { get; set; }
+		}
+
+		[Test]
+		public void ShortIsValid()
+		{
+			var model = new ShortModel() { Value = (short)5 };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void ShortIsNotValid()
+		{
+			var model = new ShortModel() { Value = default(short) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		// short?
+		private class ShortNulableModel
+		{
+			[NotDefault]
+			public short? Value { get; set; }
+		}
+
+		[Test]
+		public void ShortNulableIsValid()
+		{
+			var model = new ShortNulableModel() { Value = (short)5 };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
+
+		#region bool
+
+		private class BoolModel
+		{
+			[NotDefault]
+			public bool Value { get; set; }
+		}
+
+		[Test]
+		public void BoolIsValid()
+		{
+			var model = new BoolModel() { Value = true };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void BoolIsNotValid()
+		{
+			var model = new BoolModel() { Value = default(bool) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		// Bool?
+		private class BoolNulableModel
+		{
+			[NotDefault]
+			public bool? Value { get; set; }
+		}
+
+		[Test]
+		public void BoolNulableIsValid()
+		{
+			var model = new BoolNulableModel() { Value = true };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
+
+		#region byte
+
+		private class ByteModel
+		{
+			[NotDefault]
+			public byte Value { get; set; }
+		}
+
+		[Test]
+		public void ByteIsValid()
+		{
+			var model = new ByteModel() { Value = byte.MaxValue };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void ByteIsNotValid()
+		{
+			var model = new ByteModel() { Value = default(byte) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		// byte?
+		private class byteNulableModel
+		{
+			[NotDefault]
+			public byte? Value { get; set; }
+		}
+
+		[Test]
+		public void ByteNulableIsValid()
+		{
+			var model = new byteNulableModel() { Value = byte.MaxValue };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
+
+		#region String
+
+		private class StringModel
+		{
+			[NotDefault]
+			public string Value { get; set; }
+		}
+
+		[Test]
+		public void StringIsValid()
+		{
+			var model = new StringModel() { Value = "Hello" };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		#endregion
 	}
 }

--- a/HermaFx.DataAnnotations.Tests/NotDefaultTest.cs
+++ b/HermaFx.DataAnnotations.Tests/NotDefaultTest.cs
@@ -1,0 +1,38 @@
+﻿
+using NUnit.Framework;
+using System;
+
+namespace HermaFx.DataAnnotations
+{
+	[TestFixture]
+	public class NotDefaultTest
+	{
+		private class Model
+		{
+			[NotDefault]
+			public Guid Value { get; set; }
+		}
+
+		[Test]
+		public void IsValid()
+		{
+			var model = new Model() { Value = Guid.NewGuid() };
+			ExtendedValidator.EnsureIsValid(model);
+		}
+
+		[Test]
+		public void IsNotValid()
+		{
+			var model = new Model() { Value = default(Guid) };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+		[Test]
+		public void IsNotValidWithNulls()
+		{
+			var model = new Model() { };
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(model));
+		}
+
+	}
+}

--- a/HermaFx.DataAnnotations/NotDefaultAttribute.cs
+++ b/HermaFx.DataAnnotations/NotDefaultAttribute.cs
@@ -11,17 +11,21 @@ namespace HermaFx.DataAnnotations
 	{
 		private const string _defaultErrorMessage = "The field {0} requires a non-default value";
 
-		public NotDefaultAttribute()
-				: base(string.Format(_defaultErrorMessage))
-		{
-		}
-
 		public override bool IsValid(object value)
 		{
 			if (value == null) return true;
 			if (!value.GetType().IsValueType) return true;
 
-			return value == value.GetType().GetDefaultValue();
+			return !object.Equals(value, value.GetType().GetDefault());
 		}
+
+		public override string FormatErrorMessage(string name)
+		{
+			if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
+				ErrorMessage = _defaultErrorMessage;
+
+			return string.Format(ErrorMessageString, name);
+		}
+
 	}
 }

--- a/HermaFx.DataAnnotations/NotDefaultAttribute.cs
+++ b/HermaFx.DataAnnotations/NotDefaultAttribute.cs
@@ -11,6 +11,11 @@ namespace HermaFx.DataAnnotations
 	{
 		private const string _defaultErrorMessage = "The field {0} requires a non-default value";
 
+		public NotDefaultAttribute()
+				: base(() => _defaultErrorMessage)
+		{
+		}
+
 		public override bool IsValid(object value)
 		{
 			if (value == null) return true;
@@ -18,14 +23,5 @@ namespace HermaFx.DataAnnotations
 
 			return !object.Equals(value, value.GetType().GetDefault());
 		}
-
-		public override string FormatErrorMessage(string name)
-		{
-			if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
-				ErrorMessage = _defaultErrorMessage;
-
-			return string.Format(ErrorMessageString, name);
-		}
-
 	}
 }

--- a/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
@@ -9,6 +9,7 @@ namespace HermaFx
 		//a thread-safe way to hold default instances created at run-time
 		private static ConcurrentDictionary<Type, object> typeDefaults = new ConcurrentDictionary<Type, object>();
 
+		// Extracted from : http://stackoverflow.com/a/7881481
 		public static object GetDefault(this Type type)
 		{
 			Guard.IsNotNull(type, nameof(type));
@@ -23,7 +24,7 @@ namespace HermaFx
 				throw new ArgumentException($"The supplied value type <{type}> contains generic parameters, so the default value cannot be retrieved");
 			}
 
-			// If the Type is a primitive type, or if it is another publicly-visible value type (i.e. struct), return a 
+			// If the Type is a primitive type, or if it is another publicly-visible value type (i.e. struct), return a
 			//  default instance of the value type
 			if (type.IsPrimitive || !type.IsNotPublic)
 			{

--- a/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
@@ -6,16 +6,17 @@ namespace HermaFx
 {
 	public static class TypeExtension
 	{
-		//a thread-safe way to hold default instances created at run-time
+		//A thread-safe way to hold default instances created at run-time
 		private static ConcurrentDictionary<Type, object> typeDefaults = new ConcurrentDictionary<Type, object>();
 
-		// Extracted from : http://stackoverflow.com/a/7881481
+		// Copied from : http://stackoverflow.com/a/7881481
 		public static object GetDefault(this Type type)
 		{
+
 			Guard.IsNotNull(type, nameof(type));
 
-			// If no Type was supplied, if the Type was a reference type, or if the Type was a System.Void, return null
-			if (type == null || !type.IsValueType || type == typeof(void))
+			// If the Type was a reference type, or if the Type was a System.Void, return null
+			if (!type.IsValueType || type == typeof(void))
 				return null;
 
 			// If the supplied Type has generic parameters, its default value cannot be determined
@@ -35,8 +36,7 @@ namespace HermaFx
 				catch (Exception e)
 				{
 					throw new ArgumentException(
-					$"The Activator.CreateInstance method could not create a default instance of the supplied value type <{type}>\n\n"+
-					$"Exception message:{e.Message}", e);
+						$"The Activator.CreateInstance method could not create a default instance of the supplied value type <{type}>", e);
 				}
 			}
 

--- a/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Collections.Concurrent;
 
 namespace HermaFx
@@ -8,9 +9,39 @@ namespace HermaFx
 		//a thread-safe way to hold default instances created at run-time
 		private static ConcurrentDictionary<Type, object> typeDefaults = new ConcurrentDictionary<Type, object>();
 
-		public static object GetDefaultValue(this Type type)
+		public static object GetDefault(this Type type)
 		{
-			return type.IsValueType ? typeDefaults.GetOrAdd(type, t => Activator.CreateInstance(t)) : null;
+			Guard.IsNotNull(type, nameof(type));
+
+			// If no Type was supplied, if the Type was a reference type, or if the Type was a System.Void, return null
+			if (type == null || !type.IsValueType || type == typeof(void))
+				return null;
+
+			// If the supplied Type has generic parameters, its default value cannot be determined
+			if (type.ContainsGenericParameters)
+			{
+				throw new ArgumentException($"The supplied value type <{type}> contains generic parameters, so the default value cannot be retrieved");
+			}
+
+			// If the Type is a primitive type, or if it is another publicly-visible value type (i.e. struct), return a 
+			//  default instance of the value type
+			if (type.IsPrimitive || !type.IsNotPublic)
+			{
+				try
+				{
+					return typeDefaults.GetOrAdd(type, t => Activator.CreateInstance(t));
+				}
+				catch (Exception e)
+				{
+					throw new ArgumentException(
+					$"The Activator.CreateInstance method could not create a default instance of the supplied value type <{type}>\n\n"+
+					$"Exception message:{e.Message}", e);
+				}
+			}
+
+			// Fail with exception
+			throw new ArgumentException($"The supplied value type <{type}> is not a publicly-visible type, so the default value cannot be retrieved");
 		}
+
 	}
 }


### PR DESCRIPTION
This branch apply some fixes to NotDefaultAttribute:

- Use a new method **GetDefault** (caching) instead of our original **GetDefaultValue**.
- Fix issue with string.formtat for error message using and use the native method **FormatErrorMessage** of ValidationAttribute.
- Add NotDefault unit test.