### PR TITLE
Added SysDateOffset to RuntimeExtensions to allow mocking of a DateTimeOffSet

### DIFF
--- a/HermaFx.Foundation/HermaFx.Foundation.csproj
+++ b/HermaFx.Foundation/HermaFx.Foundation.csproj
@@ -92,6 +92,7 @@
     <Compile Include="RuntimeExtensions\LinqExtensions.cs" />
     <Compile Include="RuntimeExtensions\ReflectionExtensions.cs" />
     <Compile Include="RuntimeExtensions\StreamExtensions.cs" />
+    <Compile Include="RuntimeExtensions\SysDateOffset.cs" />
     <Compile Include="RuntimeExtensions\SysDate.cs" />
     <Compile Include="RuntimeExtensions\TypeExtensions.cs" />
     <Compile Include="Text\EncodingConverter.cs" />

--- a/HermaFx.Foundation/RuntimeExtensions/SysDateOffset.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/SysDateOffset.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HermaFx
+{
+	public static class SysDateOffset
+	{
+		public static Func<DateTimeOffset> NowDelegate { get; set; }
+		public static Func<DateTimeOffset> UtcNowDelegate { get; set; }
+
+		public static DateTimeOffset Now
+		{
+			get
+			{
+				if (NowDelegate == null)
+					return DateTimeOffset.Now;
+
+				return NowDelegate();
+			}
+		}
+
+		public static DateTimeOffset UtcNow
+		{
+			get
+			{
+				if (UtcNowDelegate == null)
+					return DateTimeOffset.UtcNow;
+
+				return UtcNowDelegate();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added SysDateOffset to RuntimeExtensions to allow mocking of a DateTimeOffSet.