### PR TITLE
Encoding Converter Tests & Modify Settings Behaviour to use ConvertFrom overload  with ITypeDescriptorContext

### DIFF
--- a/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
+++ b/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
@@ -56,7 +56,6 @@
     <Compile Include="AdvancedGuidParserFixture.cs" />
     <Compile Include="AdvancedGuidGeneratorTests.cs" />
     <Compile Include="Base32EncodingTests.cs" />
-    <Compile Include="Text\EncodingConverterTests.cs" />
     <Compile Include="ComponentModel\StringArrayConverterTests.cs" />
     <Compile Include="GuardTests.cs" />
     <Compile Include="Cryptography\CryptoHelperTests.cs" />
@@ -82,10 +81,6 @@
     <ProjectReference Include="..\HermaFx.Foundation\HermaFx.Foundation.csproj">
       <Project>{0c13f477-7360-4831-9d62-9c5b183224c8}</Project>
       <Name>HermaFx.Foundation</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\HermaFx.SettingsAdapter\HermaFx.SettingsAdapter.csproj">
-      <Project>{25cde825-0c23-4e8d-bdf0-4aa8cc07c393}</Project>
-      <Name>HermaFx.SettingsAdapter</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
+++ b/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="AdvancedGuidParserFixture.cs" />
     <Compile Include="AdvancedGuidGeneratorTests.cs" />
     <Compile Include="Base32EncodingTests.cs" />
+    <Compile Include="Text\EncodingConverterTests.cs" />
     <Compile Include="ComponentModel\StringArrayConverterTests.cs" />
     <Compile Include="GuardTests.cs" />
     <Compile Include="Cryptography\CryptoHelperTests.cs" />
@@ -82,6 +83,10 @@
       <Project>{0c13f477-7360-4831-9d62-9c5b183224c8}</Project>
       <Name>HermaFx.Foundation</Name>
     </ProjectReference>
+    <ProjectReference Include="..\HermaFx.SettingsAdapter\HermaFx.SettingsAdapter.csproj">
+      <Project>{25cde825-0c23-4e8d-bdf0-4aa8cc07c393}</Project>
+      <Name>HermaFx.SettingsAdapter</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -89,6 +94,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/HermaFx.Foundation.Tests/Text/EncodingConverterTests.cs
+++ b/HermaFx.Foundation.Tests/Text/EncodingConverterTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Text;
+using System.ComponentModel;
+using System.Collections.Specialized;
+
+using NUnit.Framework;
+
+using HermaFx.Settings;
+
+namespace HermaFx.Text
+{
+	[TestFixture]
+	public class EncodingConverterTest
+	{
+		#region Fake Encoding
+		private class FakeEncoding : Encoding
+		{
+			#region Not Implemented Methods
+			public override int GetByteCount(char[] chars, int index, int count)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int GetCharCount(byte[] bytes, int index, int count)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int GetMaxByteCount(int charCount)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int GetMaxCharCount(int byteCount)
+			{
+				throw new NotImplementedException();
+			}
+			#endregion
+
+			#region Properties
+			public override string BodyName
+			{
+				get
+				{
+					return "FAKE";
+				}
+			}
+
+			public override string EncodingName
+			{
+				get
+				{
+					return "FAKE Encoding";
+				}
+			}
+			#endregion
+		}
+		#endregion
+
+		[Settings]
+		public interface DataCoding
+		{
+			[DefaultValue("FAKE")]
+			[TypeConverter(typeof(EncodingConverter))]
+			[EncodingResolver(new [] { typeof(FakeEncoding) })]
+			Encoding Encoder { get; set; }
+		}
+
+		private static readonly NameValueCollection _dict = new NameValueCollection()
+		{
+			{ typeof(DataCoding).Namespace + ":Encoder", "FAKE" }
+		};
+
+		[Test]
+		public void EncodingConverterWithValueFakeEncoding()
+		{
+			var model = new SettingsAdapter().Create<DataCoding>(_dict);
+
+			Assert.AreEqual(model.Encoder.GetType(), typeof(FakeEncoding), "#0");
+		}
+	}
+}

--- a/HermaFx.Foundation/Text/EncodingConverter.cs
+++ b/HermaFx.Foundation/Text/EncodingConverter.cs
@@ -49,7 +49,7 @@ namespace HermaFx.Text
 			var resolver = GetResolver(context);
 
 			if (resolver != null && !AllEncodings.Any(x => x == name.ToLowerInvariant()))
-				return _resolver.GetEncoding(name);
+				return resolver.GetEncoding(name);
 
 			return Encoding.GetEncoding(name);
 		}

--- a/HermaFx.Foundation/Text/EncodingConverter.cs
+++ b/HermaFx.Foundation/Text/EncodingConverter.cs
@@ -15,7 +15,7 @@ namespace HermaFx.Text
 		private IEncodingResolver _resolver;
 
 		#region .ctor
-		private EncodingConverter(Type resolver)
+		public EncodingConverter(Type resolver)
 		{
 			_resolver = (IEncodingResolver)Activator.CreateInstance(resolver);
 		}
@@ -26,22 +26,10 @@ namespace HermaFx.Text
 		}
 		#endregion
 
-		#region Factory Methods
-		public static EncodingConverter Using(Type resolver)
-		{
-			return new EncodingConverter(resolver);
-		}
-
-		public static EncodingConverter Using(IEncodingResolver resolver)
-		{
-			return Using(resolver.GetType());
-		}
-		#endregion
-
 		private IEncodingResolver GetResolver(ITypeDescriptorContext context)
 		{
 			var attr = context?.PropertyDescriptor.Attributes.OfType<EncodingResolverAttribute>().SingleOrDefault();
-			return attr != null ? attr.GetResolver() : _resolver;
+			return attr ?? _resolver;
 		}
 
 		private Encoding GetEncoding(ITypeDescriptorContext context, string name)

--- a/HermaFx.Foundation/Text/EncodingResolverAttribute.cs
+++ b/HermaFx.Foundation/Text/EncodingResolverAttribute.cs
@@ -7,21 +7,16 @@ namespace HermaFx.Text
 	[AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
 	public class EncodingResolverAttribute : Attribute, IEncodingResolver
 	{
-		private readonly Type _resolver;
 		private readonly Encoding[] _encodings;
 
-		public EncodingResolverAttribute(Type resolver)
+		#region .ctor
+		public	EncodingResolverAttribute()
 		{
-			Guard.IsNotNull(resolver, nameof(resolver));
-			Guard.Against<ArgumentOutOfRangeException>(
-				!typeof(IEncodingResolver).IsAssignableFrom(resolver),
-				"Type {0} does not implement {1}", resolver.FullName, typeof(IEncodingResolver).FullName
-			);
 
-			_resolver = resolver;
 		}
 
 		public EncodingResolverAttribute(params Type[] encodings)
+			: this()
 		{
 			Guard.IsNotNull(encodings, nameof(encodings));
 			Guard.Against<ArgumentOutOfRangeException>(
@@ -31,16 +26,24 @@ namespace HermaFx.Text
 
 			_encodings = encodings.Select(x => (Encoding)Activator.CreateInstance(x)).ToArray();
 		}
+		#endregion
 
 		public Encoding GetEncoding(string name)
 		{
 			Guard.IsNotNullNorWhitespace(name, nameof(name));
+			// FIXME: Throw a more meaningfull exception if encoding is not available.
 			return _encodings.Single(x => x.BodyName.ToLowerInvariant() == name.ToLowerInvariant());
 		}
 
-		public IEncodingResolver GetResolver()
-		{
-			return _encodings != null ? this : (IEncodingResolver)Activator.CreateInstance(_resolver);
-		}
+		//public IEncodingResolver GetResolver()
+		//{
+		//	Guard.Against<InvalidOperationException>(_encodings == null && ResolverType == null)
+		//	Guard.Against<ArgumentOutOfRangeException>(
+		//		!typeof(IEncodingResolver).IsAssignableFrom(resolver),
+		//		"Type {0} does not implement {1}", resolver.FullName, typeof(IEncodingResolver).FullName
+		//	);
+
+		//	return _encodings != null ? this : (IEncodingResolver)Activator.CreateInstance(_resolver);
+		//}
 	}
 }

--- a/HermaFx.Foundation/Text/EncodingResolverAttribute.cs
+++ b/HermaFx.Foundation/Text/EncodingResolverAttribute.cs
@@ -14,7 +14,7 @@ namespace HermaFx.Text
 		{
 			Guard.IsNotNull(resolver, nameof(resolver));
 			Guard.Against<ArgumentOutOfRangeException>(
-				typeof(IEncodingResolver).IsAssignableFrom(resolver), 
+				!typeof(IEncodingResolver).IsAssignableFrom(resolver),
 				"Type {0} does not implement {1}", resolver.FullName, typeof(IEncodingResolver).FullName
 			);
 

--- a/HermaFx.SettingsAdapter.Tests/HermaFx.SettingsAdapter.Tests.csproj
+++ b/HermaFx.SettingsAdapter.Tests/HermaFx.SettingsAdapter.Tests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="SettingsAdapterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Text\EncodingConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HermaFx.DataAnnotations\HermaFx.DataAnnotations.csproj">

--- a/HermaFx.SettingsAdapter.Tests/Text/EncodingConverterTests.cs
+++ b/HermaFx.SettingsAdapter.Tests/Text/EncodingConverterTests.cs
@@ -72,7 +72,7 @@ namespace HermaFx.Text
 		{
 			[DefaultValue("FAKE")]
 			[TypeConverter(typeof(EncodingConverter))]
-			[EncodingResolver(new [] { typeof(FakeEncoding) })]
+			[EncodingResolver(typeof(FakeEncoding))]
 			Encoding Encoder { get; set; }
 		}
 
@@ -87,6 +87,15 @@ namespace HermaFx.Text
 			var model = new SettingsAdapter().Create<DataCoding>(_dict);
 
 			Assert.AreEqual(model.Encoder.GetType(), typeof(FakeEncoding), "#0");
+		}
+
+		[Test]
+		public void EncodingUsingTypeDescriptorGetConverter()
+		{
+			var properties = TypeDescriptor.GetProperties(typeof(DataCoding));
+			var converter = properties[0].Converter;
+
+			Assert.IsNotNull(converter);
 		}
 	}
 }

--- a/HermaFx.SettingsAdapter/GenericTypeDescriptorContext.cs
+++ b/HermaFx.SettingsAdapter/GenericTypeDescriptorContext.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HermaFx.Settings
+{
+	public class GenericTypeDescriptorContext : ITypeDescriptorContext
+	{
+		#region .ctor
+		public GenericTypeDescriptorContext(PropertyInfo property)
+		{
+			PropertyDescriptor = TypeDescriptor.GetProperties(property.DeclaringType)[property.Name];
+		}
+#if false
+		public GenericTypeDescriptorContext(object instance, string propertyName)
+		{
+			Instance = instance;
+			PropertyDescriptor = TypeDescriptor.GetProperties(instance)[propertyName];
+		}
+
+		public GenericTypeDescriptorContext(object instance, PropertyDescriptor propertyDescriptor)
+		{
+			Instance = instance;
+			PropertyDescriptor = propertyDescriptor;
+		}
+#endif
+		#endregion
+
+		public PropertyDescriptor PropertyDescriptor
+		{
+			get; private set;
+		}
+
+		#region Not Implemented Functionality
+		public object Instance
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public IContainer Container
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public object GetService(Type serviceType)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void OnComponentChanged()
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool OnComponentChanging()
+		{
+			throw new NotImplementedException();
+		}
+		#endregion
+	}
+}

--- a/HermaFx.SettingsAdapter/HermaFx.SettingsAdapter.csproj
+++ b/HermaFx.SettingsAdapter/HermaFx.SettingsAdapter.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GenericTypeDescriptorContext.cs" />
     <Compile Include="SettingsAttribute.cs" />
     <Compile Include="SettingsBehavior.cs" />
     <Compile Include="SettingsAdapter.cs" />

--- a/HermaFx.SettingsAdapter/SettingsBehavior.cs
+++ b/HermaFx.SettingsAdapter/SettingsBehavior.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Castle.Components.DictionaryAdapter;
 
 using PropertyDescriptor = Castle.Components.DictionaryAdapter.PropertyDescriptor;
+using System.Globalization;
 
 namespace HermaFx.Settings
 {
@@ -142,7 +143,7 @@ namespace HermaFx.Settings
 			if (storedValue != null && !descriptor.PropertyType.IsAssignableFrom(storedValue.GetType()))
 			{
 				storedValue = descriptor.TypeConverter.CanConvertFrom(storedValue.GetType()) ?
-					descriptor.TypeConverter.ConvertFrom(storedValue)
+					descriptor.TypeConverter.ConvertFrom(new GenericTypeDescriptorContext(descriptor.Property), CultureInfo.CurrentCulture, storedValue)
 					: Convert.ChangeType(storedValue, descriptor.PropertyType);
 			}
 


### PR DESCRIPTION
- Solved two minor fixes.
- Added GenericTypeDescriptorContext that implements ITypeDescriptorContext to allow the use of context on TypeConverter attributes.
- Modified SettingsBehaviour to use ConvertFrom overload passing context when trying to get property value.
- Added new EncodingConverterTests to Herma.Foundation.Tests. It contains a simple test to check if we use a EncodingResolverAttribute with a different encoding from the system one's, if the encoding converter can use that new encoding to convert the value to set the property.