### PR TITLE
Added extension methods to DateTime to get first day of the week

### DIFF
--- a/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
+++ b/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ComponentModel\StringArrayConverterTests.cs" />
     <Compile Include="GuardTests.cs" />
     <Compile Include="Cryptography\CryptoHelperTests.cs" />
+    <Compile Include="RuntimeExtensions\DateTimeExtensionsTests.cs" />
     <Compile Include="ZBase32EncodingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/HermaFx.Foundation.Tests/RuntimeExtensions/DateTimeExtensionsTests.cs
+++ b/HermaFx.Foundation.Tests/RuntimeExtensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Globalization;
+
+using NUnit.Framework;
+
+namespace HermaFx.RuntimeExtensions
+{
+	public class DateTimeExtensionsTests
+	{
+		#region Start of Week tests
+		[Test]
+		public void Check_Date_from_StartOfWeek_Is_Correct()
+		{
+			var date1 = new DateTime(2017, 1, 1);
+			var date2 = new DateTime(2017, 1, 2);
+
+			Assert.That(date1.StartOfWeek(CultureInfo.GetCultureInfo("es")) == new DateTime(2016, 12, 26), "#1");
+			Assert.That(date2.StartOfWeek(CultureInfo.GetCultureInfo("es")) == new DateTime(2017, 1, 2), "#2");
+			Assert.That(date1.StartOfWeek(DayOfWeek.Monday) == new DateTime(2016, 12, 26), "#3");
+			Assert.That(date2.StartOfWeek(DayOfWeek.Monday) == new DateTime(2017, 1, 2), "#4");
+		}
+
+		[Test]
+		public void Check_Date_from_StartOfWeek_Is_Incorrect()
+		{
+			var date1 = new DateTime(2017, 1, 2);
+			var date2 = new DateTime(2017, 1, 1);
+
+			Assert.That(date1.StartOfWeek(CultureInfo.GetCultureInfo("es")) != new DateTime(2016, 12, 26), "#1");
+			Assert.That(date2.StartOfWeek(CultureInfo.GetCultureInfo("es")) != new DateTime(2017, 1, 2), "#2");
+			Assert.That(date1.StartOfWeek(DayOfWeek.Monday) != new DateTime(2016, 12, 26), "#3");
+			Assert.That(date2.StartOfWeek(DayOfWeek.Monday) != new DateTime(2017, 1, 2), "#4");
+		}
+		#endregion
+
+		#region End of Week tests
+		[Test]
+		public void Check_Date_from_EndOfWeek_Is_Correct()
+		{
+			var date1 = new DateTime(2017, 1, 1);
+			var date2 = new DateTime(2017, 1, 2);
+
+			Assert.That(date1.EndOfWeek(CultureInfo.GetCultureInfo("es")) == new DateTime(2017, 1, 1), "#1");
+			Assert.That(date2.EndOfWeek(CultureInfo.GetCultureInfo("es")) == new DateTime(2017, 1, 8), "#2");
+			Assert.That(date1.EndOfWeek(DayOfWeek.Sunday) == new DateTime(2017, 1, 1), "#3");
+			Assert.That(date2.EndOfWeek(DayOfWeek.Sunday) == new DateTime(2017, 1, 8), "#4");
+		}
+
+		[Test]
+		public void Check_Date_from_EndOfWeek_Is_Incorrect()
+		{
+			var date1 = new DateTime(2017, 1, 2);
+			var date2 = new DateTime(2017, 1, 1);
+
+			Assert.That(date1.EndOfWeek(CultureInfo.GetCultureInfo("es")) != new DateTime(2017, 1, 1), "#1");
+			Assert.That(date2.EndOfWeek(CultureInfo.GetCultureInfo("es")) != new DateTime(2017, 1, 8), "#2");
+			Assert.That(date1.EndOfWeek(DayOfWeek.Sunday) != new DateTime(2017, 1, 1), "#3");
+			Assert.That(date2.EndOfWeek(DayOfWeek.Sunday) != new DateTime(2017, 1, 8), "#4");
+		}
+		#endregion
+	}
+}

--- a/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
@@ -73,8 +73,7 @@ namespace HermaFx
 		/// <returns></returns>
 		public static DateTime StartOfWeek(this DateTime date)
 		{
-			var culture = CultureInfo.CurrentCulture;
-			return date.StartOfWeek(culture);
+			return date.StartOfWeek(CultureInfo.CurrentCulture);
 		}
 
 		/// <summary>
@@ -83,9 +82,9 @@ namespace HermaFx
 		/// <param name="date">The date.</param>
 		/// <param name="culture">The culture.</param>
 		/// <returns></returns>
-		public static DateTime StartOfWeek(this DateTime date, CultureInfo culture)
+		public static DateTime StartOfWeek(this DateTime date, IFormatProvider format)
 		{
-			var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+			var firstDayOfWeek = ((DateTimeFormatInfo) format.GetFormat(typeof(DateTimeFormatInfo))).FirstDayOfWeek;
 			return date.StartOfWeek(firstDayOfWeek);
 		}
 
@@ -114,8 +113,7 @@ namespace HermaFx
 		/// <returns></returns>
 		public static DateTime EndOfWeek(this DateTime date)
 		{
-			var culture = CultureInfo.CurrentCulture;
-			return date.EndOfWeek(culture);
+			return date.EndOfWeek(CultureInfo.CurrentCulture);
 		}
 
 		/// <summary>
@@ -124,9 +122,9 @@ namespace HermaFx
 		/// <param name="date">The date.</param>
 		/// <param name="culture">The culture.</param>
 		/// <returns></returns>
-		public static DateTime EndOfWeek(this DateTime date, CultureInfo culture)
+		public static DateTime EndOfWeek(this DateTime date, IFormatProvider format)
 		{
-			var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+			var firstDayOfWeek = ((DateTimeFormatInfo)format.GetFormat(typeof(DateTimeFormatInfo))).FirstDayOfWeek;
 			var endDayOfWeek = (DayOfWeek) (((int) firstDayOfWeek + 6) % 7);
 			return date.EndOfWeek(endDayOfWeek);
 		}

--- a/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -56,6 +57,51 @@ namespace HermaFx
 		public static DateTimeOffset ToDateTimeOffset(this long secondsSince1970)
 		{
 			return new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(secondsSince1970);
+		}
+	}
+
+	/// <summary>
+	/// Provides useful extension methods for DateTime type
+	/// </summary>
+	public static class DateTimeExtensions
+	{
+		/// <summary>
+		/// Returns the date for the first day of the week for current thread culture.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <returns></returns>
+		public static DateTime StartOfWeek(this DateTime date)
+		{
+			var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
+			return date.StartOfWeek(culture);
+		}
+
+		/// <summary>
+		/// Return the date for the first day of the week for the specified culture.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <param name="culture">The culture.</param>
+		/// <returns></returns>
+		public static DateTime StartOfWeek(this DateTime date, CultureInfo culture)
+		{
+			var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+			return date.StartOfWeek(firstDayOfWeek);
+		}
+
+		/// <summary>
+		/// Return the date for the first day of the week.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <param name="startOfWeek">The start of week.</param>
+		/// <returns></returns>
+		public static DateTime StartOfWeek (this DateTime date, DayOfWeek startOfWeek)
+		{
+			int diff = date.DayOfWeek - startOfWeek;
+
+			if (diff < 0)
+				diff += 7;
+
+			return date.AddDays(-diff).Date;
 		}
 	}
 }

--- a/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/DateTimeExtensions.cs
@@ -65,6 +65,7 @@ namespace HermaFx
 	/// </summary>
 	public static class DateTimeExtensions
 	{
+		#region StartOfWeek
 		/// <summary>
 		/// Returns the date for the first day of the week for current thread culture.
 		/// </summary>
@@ -72,7 +73,7 @@ namespace HermaFx
 		/// <returns></returns>
 		public static DateTime StartOfWeek(this DateTime date)
 		{
-			var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
+			var culture = CultureInfo.CurrentCulture;
 			return date.StartOfWeek(culture);
 		}
 
@@ -103,5 +104,48 @@ namespace HermaFx
 
 			return date.AddDays(-diff).Date;
 		}
+		#endregion
+
+		#region EndOfWeek
+		/// <summary>
+		/// Returns the date for the last day of the week for current thread culture.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <returns></returns>
+		public static DateTime EndOfWeek(this DateTime date)
+		{
+			var culture = CultureInfo.CurrentCulture;
+			return date.EndOfWeek(culture);
+		}
+
+		/// <summary>
+		/// Return the date for the last day of the week for the specified culture.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <param name="culture">The culture.</param>
+		/// <returns></returns>
+		public static DateTime EndOfWeek(this DateTime date, CultureInfo culture)
+		{
+			var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+			var endDayOfWeek = (DayOfWeek) (((int) firstDayOfWeek + 6) % 7);
+			return date.EndOfWeek(endDayOfWeek);
+		}
+
+		/// <summary>
+		/// Return the date for the last day of the week.
+		/// </summary>
+		/// <param name="date">The date.</param>
+		/// <param name="startOfWeek">The end of week.</param>
+		/// <returns></returns>
+		public static DateTime EndOfWeek(this DateTime date, DayOfWeek endOfWeek)
+		{
+			int diff = endOfWeek - date.DayOfWeek;
+
+			if (diff < 0)
+				diff += 7;
+
+			return date.AddDays(diff).Date;
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Added extension methods to DateTime to get first/last day of the week for an specified datetime, with overload for:
- Specifying a culture.
- Specifyin a DayOfWeek indicating the start/endOfWeek.
- With no arguments taking the culture from CultureInfo.CurrentCulture.