### PR TITLE
Added RemoveErrorQueueOnDispose to HermaFx.Rebus to AutoDeleteErrorQueue

### DIFF
--- a/HermaFx.Rebus/TransportConfigurerExtensions.cs
+++ b/HermaFx.Rebus/TransportConfigurerExtensions.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 
 using Rebus;
-using Rebus.Configuration;
 using Rebus.RabbitMQ;
+using Rebus.Configuration;
 
 namespace HermaFx.Rebus
 {
@@ -19,6 +16,21 @@ namespace HermaFx.Rebus
 			string hostName = Dns.GetHostName();
 			return (hostName.Contains(".")) ? hostName.Substring(0, hostName.IndexOf(".")) : hostName;
 		}
+
+		private static void DeleteQueue(string connectionString, string queueName)
+		{
+			//XXX: No need to remove subscriptions due to Error Queue nature that has not subscriptions like input's one.
+			using (var connection = new RabbitMQ.Client.ConnectionFactory { Uri = connectionString }.CreateConnection())
+			using (var model = connection.CreateModel())
+			{
+				// just ignore if it fails...
+				try
+				{
+					model.QueueDelete(queueName, ifUnused: true, ifEmpty: true);
+				}
+				catch { }
+			}
+		}
 		#endregion
 
 		public static RabbitMqOptions UseRabbitMqFromConfigWithLocalName(this RebusTransportConfigurer configurer, string connectionString, string separator)
@@ -27,14 +39,26 @@ namespace HermaFx.Rebus
 			section.VerifyPresenceOfInputQueueConfig();
 			section.VerifyPresenceOfErrorQueueConfig();
 			var hostname = GetHostName();
-			var inputQueue = string.Format("{0}{2}{1}", section.InputQueue, hostname, separator);
-			var errorQueue = string.Format("{0}{2}{1}", section.ErrorQueue, hostname, separator);
+			var inputQueue = $"{section.InputQueue}{separator}{hostname}";
+			var errorQueue = $"{section.ErrorQueue}{separator}{hostname}";
 			return configurer.UseRabbitMq(connectionString, inputQueue, errorQueue);
 		}
 
 		public static RabbitMqOptions UseRabbitMqFromConfigWithLocalName(this RebusTransportConfigurer configurer, string connectionString)
 		{
 			return configurer.UseRabbitMqFromConfigWithLocalName(connectionString, DEFAULT_SEPARATOR);
+		}
+
+		public static RebusTransportConfigurer RemoveErrorQueueOnDispose(this RebusTransportConfigurer configurer, string connectionString, string errorQueue)
+		{
+			Guard.IsNotNullNorEmpty(connectionString, nameof(connectionString));
+			Guard.IsNotNullNorEmpty(errorQueue, nameof(errorQueue));
+
+			configurer.AddDecoration(x => x.ConfigureEvents(ev =>
+				ev.BusStopped += new BusStoppedEventHandler((bus) =>
+					DeleteQueue(connectionString, errorQueue))));
+
+			return configurer;
 		}
 	}
 }


### PR DESCRIPTION
Added extension method for RebusTransportConfigurer where you can indicate error queue name that will be removed when Bus stops.


Note: Error Queue only will be disposed if it's unused and empty.