### PR TITLE
Added overload for TempFile to allow passing Path

### DIFF
--- a/HermaFx.Foundation.Tests/IO/TempFileTests.cs
+++ b/HermaFx.Foundation.Tests/IO/TempFileTests.cs
@@ -64,7 +64,7 @@ namespace HermaFx.IO
 		{
 			var tmpPath = Path.GetTempFileName();
 
-			Assert.Throws<ArgumentException>(() => new TempFile(tmpPath), "#1");
+			Assert.Throws<IOException>(() => new TempFile(tmpPath), "#1");
 		}
 
 		[Test]

--- a/HermaFx.Foundation.Tests/IO/TempFileTests.cs
+++ b/HermaFx.Foundation.Tests/IO/TempFileTests.cs
@@ -37,5 +37,47 @@ namespace HermaFx.IO
 				Assert.That(File.ReadAllBytes(obj.FullPath), Is.EquivalentTo(data));
 			}
 		}
+
+		[Test]
+		public void CanCreateTempFileForPath()
+		{
+			var tmpPath = Path.Combine(Path.GetTempPath(), Utils.AdvancedGuidGenerator.GenerateComb().ToString());
+
+			var obj = new TempFile(tmpPath);
+
+			Assert.That(obj, Is.Not.Null, "#1");
+			Assert.That(obj.FullPath, Is.Not.Null.Or.Empty, "#2");
+			Assert.That(obj.FullPath, Is.EqualTo(tmpPath), "#2.1");
+			Assert.That(obj.ToString(), Is.Not.Null.Or.Empty, "#3");
+			Assert.That((string)obj, Is.Not.Null.Or.Empty, "#4");
+			Assert.That(obj.ToString(), Is.EqualTo(obj.FullPath), "#5");
+			Assert.That((string)obj, Is.EqualTo(obj.FullPath), "#6");
+
+			Assert.That(File.Exists(obj.FullPath), Is.True, "#7");
+
+			Assert.DoesNotThrow(() => obj.Dispose(), "#E1");
+			Assert.DoesNotThrow(() => obj.Dispose(), "#E2"); //< XXX: Try it twice..
+		}
+
+		[Test]
+		public void CannotCreateTempFileForAlreadyExistingPath()
+		{
+			var tmpPath = Path.GetTempFileName();
+
+			Assert.Throws<ArgumentException>(() => new TempFile(tmpPath), "#1");
+		}
+
+		[Test]
+		public void CanCreateTempFileFromStreamForPath()
+		{
+			var tmpPath = Path.Combine(Path.GetTempPath(), Utils.AdvancedGuidGenerator.GenerateComb().ToString());
+			var data = new byte[] { 0x1, 0x2, 0x3, 0x4, 0x5 };
+
+			using (var ms = new MemoryStream(data))
+			using (var obj = new TempFile(tmpPath, ms))
+			{
+				Assert.That(File.ReadAllBytes(obj.FullPath), Is.EquivalentTo(data));
+			}
+		}
 	}
 }

--- a/HermaFx.Foundation/IO/TempFile.cs
+++ b/HermaFx.Foundation/IO/TempFile.cs
@@ -21,8 +21,12 @@ namespace HermaFx.IO
 		}
 		public TempFile(string path)
 		{
-			Guard.Against<ArgumentException>(File.Exists(path),
+			Guard.Against<IOException>(File.Exists(path),
 				string.Format("Path {0} provided for TempFile already exists. TempFile cannot be created?!", path));
+
+			var directoryName = Path.GetDirectoryName(path);
+			Guard.Against<DirectoryNotFoundException>(!Directory.Exists(directoryName),
+				string.Format("Directory provided {0} for creating TempFile does not exists?!", directoryName));
 
 			// XXX: We create empty file to "reserve" path. Then dispose FileStream
 			File.Create(path).Dispose();

--- a/HermaFx.Foundation/IO/TempFile.cs
+++ b/HermaFx.Foundation/IO/TempFile.cs
@@ -17,12 +17,34 @@ namespace HermaFx.IO
 		public TempFile(Stream data)
 			: this()
 		{
+			CopyStreamToFullPath(data);
+		}
+		public TempFile(string path)
+		{
+			Guard.Against<ArgumentException>(File.Exists(path),
+				string.Format("Path {0} provided for TempFile already exists. TempFile cannot be created?!", path));
+
+			// XXX: We create empty file to "reserve" path. Then dispose FileStream
+			File.Create(path).Dispose();
+			this.FullPath = path;
+		}
+
+		public TempFile(string path, Stream data)
+			: this(path)
+		{
+			CopyStreamToFullPath(data);
+		}
+
+		#region Private Methods
+		private void CopyStreamToFullPath(Stream data)
+		{
 			using (var stream = File.OpenWrite(FullPath))
 			{
 				data.CopyTo(stream);
 				stream.Flush();
 			}
 		}
+		#endregion
 
 		public override string ToString()
 		{

--- a/HermaFx.Foundation/IO/TempFileStream.cs
+++ b/HermaFx.Foundation/IO/TempFileStream.cs
@@ -9,20 +9,51 @@ namespace HermaFx.IO
 
         public string FullPath => _path;
 
-        public TempFileStream(FileShare sharing)
-                : base(CreateInner(sharing))
+        public TempFileStream(FileShare sharing, FileMode fileMode, FileAccess fileAccess)
+                : base(CreateInner(sharing, fileMode, fileAccess))
         {
             _path = (Stream as FileStream).Name;
         }
 
-        public TempFileStream()
-            : this(FileShare.None)
+		public TempFileStream(FileShare sharing, FileMode fileMode)
+			: this(sharing, fileMode, FileAccess.ReadWrite)
 		{
 		}
 
-        private static Stream CreateInner(FileShare sharing)
+		public TempFileStream(FileShare sharing, FileAccess fileAccess)
+			: this(sharing, FileMode.OpenOrCreate | FileMode.Truncate, fileAccess)
+		{
+		}
+
+		public TempFileStream(FileMode fileMode, FileAccess fileAccess)
+			: this(FileShare.None, fileMode, fileAccess)
+		{
+		}
+
+		public TempFileStream(FileMode fileMode)
+			: this(FileShare.None, fileMode, FileAccess.ReadWrite)
+		{
+		}
+
+		public TempFileStream(FileAccess fileAccess)
+			: this(FileShare.None, FileMode.OpenOrCreate | FileMode.Truncate, fileAccess)
+		{
+		}
+
+		public TempFileStream(FileShare sharing)
+				: base(CreateInner(sharing, FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.ReadWrite))
+		{
+			_path = (Stream as FileStream).Name;
+		}
+
+		public TempFileStream()
+            : this(FileShare.None, FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.ReadWrite)
+		{
+		}
+
+		private static Stream CreateInner(FileShare sharing, FileMode fileMode, FileAccess fileAccess)
         {
-            return File.Open(Path.GetTempFileName(), FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.ReadWrite, sharing);
+            return File.Open(Path.GetTempFileName(), fileMode, fileAccess, sharing);
         }
 
         public override string ToString()


### PR DESCRIPTION
- Added overload for TempFile to allow passing Path for temporary file instead of being self-generated. If file already exists, throws argument exception.
- Added tests to check behaviour this new overloads.