### PR TITLE
Added Iso8601 project/library to HermaFx.

### DIFF
--- a/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
+++ b/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Functional\PatternMatcherTests.cs" />
     <Compile Include="GuardTests.cs" />
     <Compile Include="Cryptography\CryptoHelperTests.cs" />
+    <Compile Include="Iso8601Duration\PeriodBuilderTests.cs" />
     <Compile Include="RuntimeExtensions\DateTimeExtensionsTests.cs" />
     <Compile Include="ZBase32EncodingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -121,9 +122,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="IO\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/HermaFx.Foundation.Tests/Iso8601Duration/PeriodBuilderTests.cs
+++ b/HermaFx.Foundation.Tests/Iso8601Duration/PeriodBuilderTests.cs
@@ -1,0 +1,199 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HermaFx.Iso8601Duration
+{
+	public class PeriodBuilderTests
+	{
+		private PeriodBuilder _periodBuilder = null;
+
+		public PeriodBuilderTests()
+		{
+			this._periodBuilder = new PeriodBuilder();
+		}
+
+		#region DataProviders
+
+		public class NormalizeDuration_FromPattern_ShouldBeExpectedPattern_DataProvider : IEnumerable
+		{
+			public IEnumerator GetEnumerator()
+			{
+				yield return new Tuple<string, string>("PT61S", "PT1M1S");
+				yield return new Tuple<string, string>("PT61M", "PT1H1M");
+				yield return new Tuple<string, string>("PT25H", "P1DT1H");
+				yield return new Tuple<string, string>("PT58M61S", "PT59M1S");
+				yield return new Tuple<string, string>("PT59M61S", "PT1H1S");
+				yield return new Tuple<string, string>("PT23H59M61S", "P1DT1S");
+				yield return new Tuple<string, string>("P31D", "P1M1D");
+				yield return new Tuple<string, string>("P13M", "P1Y1M");
+				yield return new Tuple<string, string>("P11M31D", "P1Y1D");
+				yield return new Tuple<string, string>("P1Y", "P1Y");
+				yield return new Tuple<string, string>("P1Y31D", "P1Y1M1D");
+				yield return new Tuple<string, string>("P1Y11M31D", "P2Y1D");
+				yield return new Tuple<string, string>("P1Y11M30DT23H59M60S", "P2Y1D");
+			}
+		}
+		#endregion
+
+		[TestCaseSource(typeof(NormalizeDuration_FromPattern_ShouldBeExpectedPattern_DataProvider))]
+		public void NormalizeDuration_FromPattern_ShouldBeExpectedPattern(Tuple<string, string> @case)
+		{
+			var returnedResult = this._periodBuilder.NormalizeDuration(@case.Item1);
+			Assert.AreEqual(@case.Item2, returnedResult);
+		}
+
+		[Test]
+		public void ToString_FromDurationStruct_ShouldBeExpectedPattern()
+		{
+			var values = new List<Tuple<DurationStruct, string>>();
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Minutes = 120 }, "PT2H"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Minutes = 1440 }, "P1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Minutes = 518400 }, "P1Y"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Seconds = 3600 }, "PT1H"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Seconds = 86400 }, "P1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Seconds = 31104000 }, "P1Y"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Hours = 23, Minutes = 121 }, "P1DT1H1M"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Hours = 23, Minutes = 61 }, "P1DT1M"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Hours = 23, Minutes = 60 }, "P1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Days = 30, Hours = 24 }, "P1M1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Days = 31, Hours = 24 }, "P1M2D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Days = 31 }, "P1M1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Days = 360, Hours = 23, Minutes = 60 }, "P1Y1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Days = 365, Hours = 23, Minutes = 60 }, "P1Y1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Months = 11, Days = 31 }, "P1Y1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Years = 1, Months = 11, Days = 31 }, "P2Y1D"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Years = 1, Months = 12 }, "P2Y"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Years = 1, Months = 13 }, "P2Y1M"));
+			values.Add(new Tuple<DurationStruct, string>(new DurationStruct() { Months = 11, Days = 30, Hours = 23, Minutes = 59, Seconds = 60 }, "P1Y1D"));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToString(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+		[Test]
+		public void ToString_FromTimeSpan_ShouldBeExpectedPattern()
+		{
+			var values = new List<Tuple<TimeSpan, string>>();
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 120, 0), "PT2H"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 1440, 0), "P1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 518400, 0), "P1Y"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 0, 3600), "PT1H"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 0, 86400), "P1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(0, 0, 31104000), "P1Y"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(23, 121, 0), "P1DT1H1M"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(23, 61, 0), "P1DT1M"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(23, 60, 0), "P1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(30, 24, 0, 0), "P1M1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(31, 24, 0, 0), "P1M2D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(31, 0, 0, 0), "P1M1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(360, 23, 60, 0), "P1Y1D"));
+			values.Add(new Tuple<TimeSpan, string>(new TimeSpan(365, 23, 60, 0), "P1Y1D"));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToString(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+		[Test]
+		public void ToTimeSpan_FromPattern_ShouldBeExpectedTimeSpan()
+		{
+			var values = new List<Tuple<string, TimeSpan>>();
+			values.Add(new Tuple<string, TimeSpan>("PT2H", new TimeSpan(0, 120, 0)));
+			values.Add(new Tuple<string, TimeSpan>("PT1440M", new TimeSpan(0, 1440, 0)));
+			values.Add(new Tuple<string, TimeSpan>("PT518400M", new TimeSpan(0, 518400, 0)));
+			values.Add(new Tuple<string, TimeSpan>("PT1H", new TimeSpan(0, 0, 3600)));
+			values.Add(new Tuple<string, TimeSpan>("PT86400S", new TimeSpan(0, 0, 86400)));
+			values.Add(new Tuple<string, TimeSpan>("PT31104000S", new TimeSpan(0, 0, 31104000)));
+			values.Add(new Tuple<string, TimeSpan>("PT25H1M", new TimeSpan(23, 121, 0)));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToTimeSpan(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+		[Test]
+		public void ToTimeSpan_FromDurationStruct_ShouldBeExpectedTimeSpan()
+		{
+			var values = new List<Tuple<DurationStruct, TimeSpan>>();
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Minutes = 1440 }, new TimeSpan(0, 1440, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Minutes = 518400 }, new TimeSpan(0, 518400, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Seconds = 3600 }, new TimeSpan(0, 0, 3600)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Seconds = 86400 }, new TimeSpan(0, 0, 86400)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Hours = 23, Minutes = 121 }, new TimeSpan(23, 121, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Seconds = 31104000 }, new TimeSpan(0, 0, 31104000)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Hours = 23, Minutes = 61 }, new TimeSpan(23, 61, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Hours = 23, Minutes = 60 }, new TimeSpan(23, 60, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Days = 30, Hours = 24 }, new TimeSpan(30, 24, 0, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Days = 31, Hours = 24 }, new TimeSpan(31, 24, 0, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Days = 31 }, new TimeSpan(31, 0, 0, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Days = 360, Hours = 23, Minutes = 60 }, new TimeSpan(360, 23, 60, 0)));
+			values.Add(new Tuple<DurationStruct, TimeSpan>(new DurationStruct() { Days = 365, Hours = 23, Minutes = 60 }, new TimeSpan(366, 0, 0, 0)));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToTimeSpan(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+		[Test]
+		public void ToDurationStruct_FromPattern_ShouldBeExpectedDurationStruct()
+		{
+			var values = new List<Tuple<string, DurationStruct>>();
+			values.Add(new Tuple<string, DurationStruct>("PT1S", new DurationStruct() { Seconds = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("PT1M", new DurationStruct() { Minutes = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("PT2H", new DurationStruct() { Hours = 2 }));
+			values.Add(new Tuple<string, DurationStruct>("PT1H", new DurationStruct() { Hours = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("P1D", new DurationStruct() { Days = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("P1M", new DurationStruct() { Months = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("P1Y", new DurationStruct() { Years = 1 }));
+			values.Add(new Tuple<string, DurationStruct>("P1DT1H1M", new DurationStruct() { Days = 1, Hours = 1, Minutes = 1 }));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToDurationStruct(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+		[Test]
+		public void ToDurationStruct_FromTimeSpan_ShouldBeExpectedDurationStruct()
+		{
+			var values = new List<Tuple<TimeSpan, DurationStruct>>();
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 0, 120), new DurationStruct() { Minutes = 2 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 120, 0), new DurationStruct() { Hours = 2 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 0, 1440), new DurationStruct() { Minutes = 24 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 518400, 0), new DurationStruct() { Years = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 0, 3600), new DurationStruct() { Hours = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 0, 86400), new DurationStruct() { Days = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(0, 0, 31104000), new DurationStruct() { Years = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(23, 121, 0), new DurationStruct() { Days = 1, Hours = 1, Minutes = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(23, 61, 0), new DurationStruct() { Days = 1, Minutes = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(23, 60, 0), new DurationStruct() { Days = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(30, 24, 0, 0), new DurationStruct() { Months = 1, Days = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(31, 24, 0, 0), new DurationStruct() { Months = 1, Days = 2 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(31, 0, 0, 0), new DurationStruct() { Months = 1, Days = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(360, 23, 60, 0), new DurationStruct() { Years = 1, Days = 1 }));
+			values.Add(new Tuple<TimeSpan, DurationStruct>(new TimeSpan(365, 23, 60, 0), new DurationStruct() { Years = 1, Days = 1 }));
+
+			foreach (var item in values)
+			{
+				var returnedResult = this._periodBuilder.ToDurationStruct(item.Item1);
+				Assert.AreEqual(item.Item2, returnedResult);
+			}
+		}
+
+	}
+}

--- a/HermaFx.Foundation/HermaFx.Foundation.csproj
+++ b/HermaFx.Foundation/HermaFx.Foundation.csproj
@@ -69,6 +69,12 @@
     <Compile Include="Guard.cs" />
     <Compile Include="Guard.Expressions.cs" />
     <Compile Include="IO\GZipStreamEx.cs" />
+    <Compile Include="Iso8601Duration\Constants.cs" />
+    <Compile Include="Iso8601Duration\DurationStruct.cs" />
+    <Compile Include="Iso8601Duration\Exceptions\Iso8601DurationException.cs" />
+    <Compile Include="Iso8601Duration\Extensions\ConverterExtensions.cs" />
+    <Compile Include="Iso8601Duration\Extensions\DateTimeExtensions.cs" />
+    <Compile Include="Iso8601Duration\PeriodBuilder.cs" />
     <Compile Include="Reflection\Accessor.cs" />
     <Compile Include="Reflection\DummyPropertyInfo.cs" />
     <Compile Include="Reflection\PropertyChain.cs" />
@@ -124,9 +130,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="IO\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 			 Other similar extension points exist, see Microsoft.Common.targets.

--- a/HermaFx.Foundation/Iso8601Duration/Constants.cs
+++ b/HermaFx.Foundation/Iso8601Duration/Constants.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HermaFx.Iso8601Duration
+{
+	public sealed class Constants
+	{
+		public const string ZERO = "0";
+
+		public const string TAG_PERIOD = "P";
+		public const string TAG_TIME = "T";
+
+		public const string TAG_YEARS = "Y";
+		public const string TAG_MONTHS = "M";
+		public const string TAG_DAYS = "D";
+
+		public const string TAG_HOURS = "H";
+		public const string TAG_MINUTES = "M";
+		public const string TAG_SECONDS = "S";
+
+		public const string TAG_ZERO = TAG_PERIOD + TAG_TIME + ZERO + TAG_SECONDS;
+
+		public const int DAYS_PER_YEAR = 365;
+		public const int DAYS_PER_MONTH = 30;
+		public const int MONTHS_PER_YEAR = 12;
+
+		public const int HOURS_PER_DAY = 24;
+		public const int MINUTES_PER_HOUR = 60;
+		public const int SECONDS_PER_MINUTE = 60;
+	}
+}

--- a/HermaFx.Foundation/Iso8601Duration/DurationStruct.cs
+++ b/HermaFx.Foundation/Iso8601Duration/DurationStruct.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HermaFx.Iso8601Duration
+{
+	public struct DurationStruct
+	{
+		public int Years;
+		public int Months;
+		public int Days;
+		public int Hours;
+		public int Minutes;
+		public int Seconds;
+	}
+}

--- a/HermaFx.Foundation/Iso8601Duration/Exceptions/Iso8601DurationException.cs
+++ b/HermaFx.Foundation/Iso8601Duration/Exceptions/Iso8601DurationException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace HermaFx.Iso8601Duration
+{
+	public class Iso8601DurationException : Exception
+	{
+		public Iso8601DurationException()
+		{
+		}
+
+		public Iso8601DurationException(string message) : base(message)
+		{
+		}
+
+		public Iso8601DurationException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected Iso8601DurationException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/HermaFx.Foundation/Iso8601Duration/Extensions/ConverterExtensions.cs
+++ b/HermaFx.Foundation/Iso8601Duration/Extensions/ConverterExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace HermaFx.Iso8601Duration
+{
+	public static class ConverterExtensions
+	{
+		public static bool IsNumeric(this string input)
+		{
+			int number;
+			return int.TryParse(input, out number);
+		}
+
+		public static bool IsMonthBeforeTime(this string pattern)
+		{
+			int mOccurrences = pattern.Split(Constants.TAG_MONTHS.ToCharArray()).Length - 1;
+			int indexOfT = pattern.IndexOf(Constants.TAG_TIME);
+			int indexOfM = pattern.IndexOf(Constants.TAG_MONTHS);
+
+			if ((indexOfT > indexOfM) ||
+			   (indexOfT == -1 && indexOfM != -1 && mOccurrences != 0)) return true;
+
+			return false;
+		}
+	}
+}

--- a/HermaFx.Foundation/Iso8601Duration/Extensions/DateTimeExtensions.cs
+++ b/HermaFx.Foundation/Iso8601Duration/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace HermaFx.Iso8601Duration
+{
+	public static class DateTimeExtensions
+	{
+		public static DateTime Add(this DateTime date, string durationPattern)
+		{
+			var duration = new PeriodBuilder().ToDurationStruct(durationPattern);
+			return date
+				.AddYears(duration.Years)
+				.AddMonths(duration.Months)
+				.AddDays(duration.Days)
+				.AddHours(duration.Hours)
+				.AddMinutes(duration.Minutes)
+				.AddSeconds(duration.Seconds);
+		}
+
+		public static DateTime Add(this DateTime date, DurationStruct duration)
+		{
+			return date
+				.AddYears(duration.Years)
+				.AddMonths(duration.Months)
+				.AddDays(duration.Days)
+				.AddHours(duration.Hours)
+				.AddMinutes(duration.Minutes)
+				.AddSeconds(duration.Seconds);
+		}
+	}
+}

--- a/HermaFx.Foundation/Iso8601Duration/PeriodBuilder.cs
+++ b/HermaFx.Foundation/Iso8601Duration/PeriodBuilder.cs
@@ -1,0 +1,290 @@
+﻿using System;
+
+namespace HermaFx.Iso8601Duration
+{
+	/// <summary>
+	/// Code extracted/obtained from https://github.com/J0rgeSerran0/Iso8601Duration
+	/// We took project to HermaFx to avoid dependencies on netstandard framework, which is the one used in the original library, and its causing some problems when referencing on MONO/UNIX.
+	/// </summary>
+	public class PeriodBuilder
+	{
+		private const string EXCEPTION_GENERIC_ERROR = "A general error has occurred";
+		private const string EXCEPTION_PATTERN_NOT_VALID = "The pattern text is not valid";
+		private const string EXCEPTION_PATTERN_SHOULD_START_BY_P = "The pattern text should start with P";
+
+		private bool _isMonthBeforeTime = false;
+		private bool _isTagTimeFound = false;
+
+		private int CalculateDays(int years, int months, int days)
+		{
+			var daysInMonths = 0;
+			var daysInRest = 0;
+
+			if (months > Constants.MONTHS_PER_YEAR)
+			{
+				daysInMonths = Constants.DAYS_PER_YEAR * (months / Constants.MONTHS_PER_YEAR);
+				daysInRest = months - ((months / Constants.MONTHS_PER_YEAR) * Constants.MONTHS_PER_YEAR);
+				daysInMonths += daysInRest * Constants.DAYS_PER_MONTH;
+			}
+			else
+			{
+				daysInMonths = months * Constants.DAYS_PER_MONTH;
+			}
+
+			return (years * Constants.DAYS_PER_YEAR) + daysInMonths + days;
+		}
+
+		private string GetPatternFromDurationStruct(DurationStruct durationStruct)
+		{
+			string pattern = Constants.TAG_PERIOD;
+
+			if (durationStruct.Seconds > Constants.SECONDS_PER_MINUTE)
+			{
+				int seconds = durationStruct.Seconds / Constants.SECONDS_PER_MINUTE;
+				durationStruct.Minutes += seconds;
+				durationStruct.Seconds -= seconds * Constants.SECONDS_PER_MINUTE;
+			}
+
+			if (durationStruct.Minutes > Constants.MINUTES_PER_HOUR)
+			{
+				int minutes = durationStruct.Minutes / Constants.MINUTES_PER_HOUR;
+				durationStruct.Hours += minutes;
+				durationStruct.Minutes -= minutes * Constants.MINUTES_PER_HOUR;
+			}
+
+			if (durationStruct.Hours > Constants.HOURS_PER_DAY)
+			{
+				int days = durationStruct.Hours / Constants.HOURS_PER_DAY;
+				durationStruct.Days += days;
+				durationStruct.Hours -= days * Constants.HOURS_PER_DAY;
+			}
+
+			if (durationStruct.Minutes > Constants.MINUTES_PER_HOUR)
+			{
+				int hours = durationStruct.Minutes / Constants.MINUTES_PER_HOUR;
+				durationStruct.Hours += hours;
+				durationStruct.Minutes -= hours * Constants.MINUTES_PER_HOUR;
+			}
+
+			if (durationStruct.Days > Constants.DAYS_PER_MONTH)
+			{
+				int years = durationStruct.Days / Constants.DAYS_PER_YEAR;
+				int days = durationStruct.Days - (years * Constants.DAYS_PER_YEAR);
+				int months = (days / Constants.DAYS_PER_MONTH);
+
+				durationStruct.Years += years;
+				durationStruct.Months += months;
+				durationStruct.Days -= (years * Constants.DAYS_PER_YEAR) + (months * Constants.DAYS_PER_MONTH);
+			}
+
+			if (durationStruct.Months >= Constants.MONTHS_PER_YEAR)
+			{
+				int years = durationStruct.Months / Constants.MONTHS_PER_YEAR;
+				int months = durationStruct.Months - (years * Constants.MONTHS_PER_YEAR);
+
+				durationStruct.Years += years;
+				durationStruct.Months = months;
+			}
+
+			pattern += (durationStruct.Years > 0 ? durationStruct.Years + Constants.TAG_YEARS : String.Empty);
+			pattern += (durationStruct.Months > 0 ? durationStruct.Months + Constants.TAG_MONTHS : String.Empty);
+			pattern += (durationStruct.Days > 0 ? durationStruct.Days + Constants.TAG_DAYS : String.Empty);
+
+			var patternTime = String.Empty;
+			patternTime += (durationStruct.Hours > 0 ? durationStruct.Hours + Constants.TAG_HOURS : String.Empty);
+			patternTime += (durationStruct.Minutes > 0 ? durationStruct.Minutes + Constants.TAG_MINUTES : String.Empty);
+			patternTime += (durationStruct.Seconds > 0 ? durationStruct.Seconds + Constants.TAG_SECONDS : String.Empty);
+
+			if (!String.IsNullOrEmpty(patternTime))
+			{
+				pattern += Constants.TAG_TIME + patternTime;
+			}
+
+			return pattern;
+		}
+
+		private int GetValue(string tagPattern, ref string pattern)
+		{
+			var valueString = String.Empty;
+
+			int index = pattern.IndexOf(tagPattern);
+
+			if (index != -1)
+			{
+				if (!pattern.Substring(0, index).IsNumeric())
+				{
+					throw new Iso8601DurationException(EXCEPTION_PATTERN_NOT_VALID);
+				}
+
+				valueString = pattern.Substring(0, index);
+				pattern = pattern.Substring(index);
+
+				if (pattern.Substring(0, 1) == tagPattern)
+				{
+					pattern = pattern.Substring(1);
+				}
+				else
+				{
+					throw new Iso8601DurationException(EXCEPTION_PATTERN_NOT_VALID);
+				}
+
+				if (pattern.Length > 0 &&
+					pattern.StartsWith(Constants.TAG_TIME))
+				{
+					pattern = pattern.Substring(1);
+				}
+
+				return Convert.ToInt32(valueString);
+			}
+
+			return 0;
+		}
+
+		private DurationStruct TimeSpanToDurationStruct(TimeSpan timeSpan)
+		{
+			return new DurationStruct()
+			{
+				Days = timeSpan.Days,
+				Hours = timeSpan.Hours,
+				Minutes = timeSpan.Minutes,
+				Seconds = timeSpan.Seconds
+			};
+		}
+
+		public string NormalizeDuration(string pattern)
+		{
+			_isTagTimeFound = false;
+
+			return ToString(ToTimeSpan(pattern));
+		}
+
+		private Tuple<int, int> CalculatePeriodValues(int initialValue, int constantValue)
+		{
+			var upperValue = initialValue / constantValue;
+			var lowerValue = ((initialValue / constantValue) * constantValue);
+
+			return new Tuple<int, int>(upperValue, lowerValue);
+		}
+
+		public DurationStruct ToDurationStruct(TimeSpan timeSpan)
+		{
+			try
+			{
+				var durationStruct = TimeSpanToDurationStruct(timeSpan);
+
+				if (timeSpan.Days >= Constants.DAYS_PER_YEAR)
+				{
+					var periodValues = CalculatePeriodValues(timeSpan.Days, Constants.DAYS_PER_YEAR);
+					durationStruct.Years = periodValues.Item1;
+					durationStruct.Days -= periodValues.Item2;
+				}
+
+				if (durationStruct.Days >= Constants.DAYS_PER_MONTH)
+				{
+					var periodValues = CalculatePeriodValues(durationStruct.Days, Constants.DAYS_PER_MONTH);
+					durationStruct.Months = periodValues.Item1;
+					durationStruct.Days -= periodValues.Item2;
+				}
+
+				if (durationStruct.Months >= Constants.MONTHS_PER_YEAR)
+				{
+					var periodValues = CalculatePeriodValues(durationStruct.Months, Constants.MONTHS_PER_YEAR);
+					durationStruct.Years += periodValues.Item1;
+					durationStruct.Months -= periodValues.Item2;
+				}
+
+				return durationStruct;
+			}
+			catch (Exception ex)
+			{
+				throw new Iso8601DurationException(EXCEPTION_GENERIC_ERROR, ex);
+			}
+		}
+
+		public DurationStruct ToDurationStruct(string pattern)
+		{
+			return ToDurationStruct(ToTimeSpan(pattern));
+		}
+
+		public string ToString(TimeSpan timeSpan)
+		{
+			try
+			{
+				if (timeSpan == TimeSpan.Zero)
+				{
+					return Constants.TAG_ZERO;
+				}
+
+				var durationStruct = TimeSpanToDurationStruct(timeSpan);
+
+				return GetPatternFromDurationStruct(durationStruct);
+			}
+			catch (Exception ex)
+			{
+				throw new Iso8601DurationException(EXCEPTION_GENERIC_ERROR, ex);
+			}
+		}
+
+		public string ToString(DurationStruct durationStruct)
+		{
+			return NormalizeDuration(GetPatternFromDurationStruct(durationStruct));
+		}
+
+		public TimeSpan ToTimeSpan(string pattern)
+		{
+			try
+			{
+				_isTagTimeFound = false;
+				pattern = pattern.ToUpper().Trim();
+
+				if (!pattern.StartsWith(Constants.TAG_PERIOD))
+				{
+					throw new Iso8601DurationException(EXCEPTION_PATTERN_SHOULD_START_BY_P);
+				}
+
+				pattern = pattern.Substring(1);
+
+				if (pattern.Length == 0)
+				{
+					return new TimeSpan(0);
+				}
+
+				_isMonthBeforeTime = pattern.IsMonthBeforeTime();
+
+				if (pattern.Length > 0 &&
+					pattern.StartsWith(Constants.TAG_TIME))
+				{
+					_isTagTimeFound = true;
+					pattern = pattern.Substring(1);
+				}
+
+				var durationStruct = new DurationStruct();
+
+				if (!_isTagTimeFound)
+				{
+					durationStruct.Years = GetValue(Constants.TAG_YEARS, ref pattern);
+					if (_isMonthBeforeTime) durationStruct.Months = GetValue(Constants.TAG_MONTHS, ref pattern);
+					durationStruct.Days = GetValue(Constants.TAG_DAYS, ref pattern);
+				}
+
+				durationStruct.Hours = GetValue(Constants.TAG_HOURS, ref pattern);
+				durationStruct.Minutes = GetValue(Constants.TAG_MINUTES, ref pattern);
+				durationStruct.Seconds = GetValue(Constants.TAG_SECONDS, ref pattern);
+
+				return ToTimeSpan(durationStruct);
+			}
+			catch (Exception ex)
+			{
+				throw new Iso8601DurationException(EXCEPTION_GENERIC_ERROR, ex);
+			}
+		}
+
+		public TimeSpan ToTimeSpan(DurationStruct durationStruct)
+		{
+			durationStruct.Days = CalculateDays(durationStruct.Years, durationStruct.Months, durationStruct.Days);
+
+			return new TimeSpan(durationStruct.Days, durationStruct.Hours, durationStruct.Minutes, durationStruct.Seconds);
+		}
+
+	}
+}


### PR DESCRIPTION
Added Iso8601 project/library to HermaFx from https://github.com/J0rgeSerran0/Iso8601Duration.

We took project to HermaFx to avoid dependencies on netstandard framework, which is the one used in the original library, and its causing some problems when referencing on MONO/UNIX.