### PR TITLE
Add IfNotNullOrWhiteSpace action

### DIFF
--- a/HermaFx.Foundation/RuntimeExtensions/StringExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/StringExtensions.cs
@@ -96,6 +96,20 @@ namespace HermaFx
 			}
 			return lambda(@this);
 		}
+		
+		/// <summary>
+		/// Exectues action over element if it is not null, empty nor whitespace string
+		/// </summary>
+		/// <param name="@this">The @this.</param>
+		/// <param name="lambda">Action to apply.</param>
+		/// <returns></returns>
+		public static void IfNotNullOrWhiteSpace(this string @this, Action<string> lambda)
+		{
+			if (!@this.IsNullOrWhiteSpace())
+			{
+				return lambda(@this);
+			}
+		}
 		#endregion
 
 		public static string TrimOrDefault(this string @this)


### PR DESCRIPTION
Add IfNotNullOrWhiteSpace method to StringExtensions that allows to pass an action method that return nothing that allows code like:

```csharp
myString.IfNotNullOrWhiteSpace(s => myArray.Add(s));
```