### PR TITLE
Oops, change visibility from internal to public in AsyncHelpers

### DIFF
--- a/HermaFx.Foundation/Utils/AsyncHelpers.cs
+++ b/HermaFx.Foundation/Utils/AsyncHelpers.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace HermaFx.Utils
 {
-	internal static class AsyncHelpers
+	public static class AsyncHelpers
 	{
 		#region Inner Types
 


### PR DESCRIPTION
My bad, forgot to make it public instead of internal jaja