### PR TITLE
Create Dictionary Validation based on ValidateElementUsingAttribute

### DIFF
--- a/HermaFx.DataAnnotations.Tests/ValidateKeysUsingTests.cs
+++ b/HermaFx.DataAnnotations.Tests/ValidateKeysUsingTests.cs
@@ -7,23 +7,23 @@ using NUnit.Framework;
 namespace HermaFx.DataAnnotations
 {
 	[TestFixture]
-	public class ValidateElementsUsingTests
+	public class ValidateKeysUsingTests
 	{
 		public class TestDtoMetadata
 		{
-			[MinLength(5)]
-			private string StringProperty { get; set; }
+			[Regex(@"^[a-z]{4,10}$")]
+			private string KeyProperty { get; set; }
 		}
 
 		public class TestDto
 		{
-			[ValidateElementsUsing(typeof(TestDtoMetadata), "StringProperty")]
-			public IEnumerable<string> StringList { get; set; }
+			[ValidateKeysUsing(typeof(TestDtoMetadata), "KeyProperty")]
+			public Dictionary<string, string> TestProperty { get; set; }
 		}
 
 		public class BadTypeDto
 		{
-			[ValidateElementsUsing(typeof(TestDtoMetadata), "StringProperty")]
+			[ValidateKeysUsing(typeof(TestDtoMetadata), "KeyProperty")]
 			public TestDto TestProperty { get; set; }
 		}
 
@@ -32,23 +32,21 @@ namespace HermaFx.DataAnnotations
 		{
 			var @null = new TestDto()
 			{
-				StringList = null
+				TestProperty = null
 			};
 			var empty = new TestDto()
 			{
-				StringList = new string[] { }
+				TestProperty = new Dictionary<string, string>()
 			};
 			var good = new TestDto()
 			{
-				StringList = new[] { "abcde" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("good", "dummy") })
 			};
 			var bad = new TestDto()
 			{
-				StringList = new[] { "a" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("bad", "dummy") })
 			};
 
-			ExtendedValidator.EnsureIsValid(@null);
-			ExtendedValidator.EnsureIsValid(empty);
 			ExtendedValidator.EnsureIsValid(good);
 			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(bad));
 		}
@@ -58,7 +56,7 @@ namespace HermaFx.DataAnnotations
 		{
 			var good = new TestDto()
 			{
-				StringList = new[] { "abcde" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("success", "dummy") })
 			};
 
 			var results = new List<ValidationResult>();
@@ -66,7 +64,7 @@ namespace HermaFx.DataAnnotations
 		}
 
 		[Test]
-		public void BadTypeNullTest()
+		public void ValidateBadTypeTest()
 		{
 			var ignore = new BadTypeDto()
 			{
@@ -77,13 +75,12 @@ namespace HermaFx.DataAnnotations
 			{
 				TestProperty = new TestDto()
 				{
-					StringList = new[] { "aaaaaa" }
+					TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("ïgnore", "ïgnore") })
 				}
 			};
 
 			ExtendedValidator.EnsureIsValid(ignore);
 			Assert.Throws<ValidationException>(() => ExtendedValidator.EnsureIsValid(bad));
 		}
-
 	}
 }

--- a/HermaFx.DataAnnotations.Tests/ValidateValuessUsingTests.cs
+++ b/HermaFx.DataAnnotations.Tests/ValidateValuessUsingTests.cs
@@ -7,23 +7,23 @@ using NUnit.Framework;
 namespace HermaFx.DataAnnotations
 {
 	[TestFixture]
-	public class ValidateElementsUsingTests
+	public class ValidateValuessUsingTests
 	{
 		public class TestDtoMetadata
 		{
-			[MinLength(5)]
-			private string StringProperty { get; set; }
+			[Regex(@"^[a-z]{4,10}$")]
+			private string ValueProperty { get; set; }
 		}
 
 		public class TestDto
 		{
-			[ValidateElementsUsing(typeof(TestDtoMetadata), "StringProperty")]
-			public IEnumerable<string> StringList { get; set; }
+			[ValidateValuesUsing(typeof(TestDtoMetadata), "ValueProperty")]
+			public Dictionary<string, string> TestProperty { get; set; }
 		}
 
 		public class BadTypeDto
 		{
-			[ValidateElementsUsing(typeof(TestDtoMetadata), "StringProperty")]
+			[ValidateValuesUsing(typeof(TestDtoMetadata), "ValueProperty")]
 			public TestDto TestProperty { get; set; }
 		}
 
@@ -32,23 +32,21 @@ namespace HermaFx.DataAnnotations
 		{
 			var @null = new TestDto()
 			{
-				StringList = null
+				TestProperty = null
 			};
 			var empty = new TestDto()
 			{
-				StringList = new string[] { }
+				TestProperty = new Dictionary<string, string>()
 			};
 			var good = new TestDto()
 			{
-				StringList = new[] { "abcde" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", "good") })
 			};
 			var bad = new TestDto()
 			{
-				StringList = new[] { "a" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", "bad") })
 			};
 
-			ExtendedValidator.EnsureIsValid(@null);
-			ExtendedValidator.EnsureIsValid(empty);
 			ExtendedValidator.EnsureIsValid(good);
 			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(bad));
 		}
@@ -58,7 +56,7 @@ namespace HermaFx.DataAnnotations
 		{
 			var good = new TestDto()
 			{
-				StringList = new[] { "abcde" }
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", "success") })
 			};
 
 			var results = new List<ValidationResult>();
@@ -66,7 +64,7 @@ namespace HermaFx.DataAnnotations
 		}
 
 		[Test]
-		public void BadTypeNullTest()
+		public void ValidateBadTypeTest()
 		{
 			var ignore = new BadTypeDto()
 			{
@@ -77,13 +75,12 @@ namespace HermaFx.DataAnnotations
 			{
 				TestProperty = new TestDto()
 				{
-					StringList = new[] { "aaaaaa" }
+					TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("ïgnore", "ïgnore") })
 				}
 			};
 
 			ExtendedValidator.EnsureIsValid(ignore);
 			Assert.Throws<ValidationException>(() => ExtendedValidator.EnsureIsValid(bad));
 		}
-
 	}
 }

--- a/HermaFx.DataAnnotations/ValidateElementsUsingAttribute.cs
+++ b/HermaFx.DataAnnotations/ValidateElementsUsingAttribute.cs
@@ -45,6 +45,14 @@ namespace HermaFx.DataAnnotations
 
 		#endregion
 
+		protected virtual void CheckTargetType(object value, string memberName)
+		{
+			if (!(value is IEnumerable))
+				throw new ValidationException($"Property {memberName} is not enumerable.");
+		}
+
+		protected virtual IEnumerable GetEnumerable(object value) => value as IEnumerable;
+
 		private IEnumerable<ValidationResult> ValidateClass(object value, ValidationContext context, IEnumerable<ValidationAttribute> attributes)
 		{
 			var results = new List<ValidationResult>();
@@ -107,10 +115,7 @@ namespace HermaFx.DataAnnotations
 				return ValidationResult.Success;
 			}
 
-			if (!(value is IEnumerable))
-			{
-				throw new ValidationException("Property {0} is not enumerable.".Format(context.MemberName as object));
-			}
+			CheckTargetType(value, context.MemberName);
 
 			var property = MetadataType.GetRuntimeProperties().SingleOrDefault(x => x.Name == Property);
 
@@ -125,7 +130,7 @@ namespace HermaFx.DataAnnotations
 			if (attributes.Any())
 			{
 				var idx = 0;
-				var valueAsEnumerable = value as IEnumerable;
+				var valueAsEnumerable = GetEnumerable(value);
 				foreach (var item in valueAsEnumerable)
 				{
 					var idx2 = idx++;

--- a/HermaFx.DataAnnotations/ValidateKeysUsingAttribute.cs
+++ b/HermaFx.DataAnnotations/ValidateKeysUsingAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+
+namespace HermaFx.DataAnnotations
+{
+	[AttributeUsage(AttributeTargets.Property)]
+	public class ValidateKeysUsingAttribute : ValidateElementsUsingAttribute
+	{
+		#region .ctor
+
+		public ValidateKeysUsingAttribute(Type metadataType, string propertyName)
+			: base(metadataType, propertyName) { }
+
+		public ValidateKeysUsingAttribute(Type metadataType, string propertyName, string errorMessage)
+			: base(metadataType, propertyName, errorMessage)
+		{
+		}
+
+		#endregion
+
+		protected override void CheckTargetType(object value, string memberName)
+		{
+			if (!(value is IDictionary))
+				throw new ValidationException($"Property {memberName} is not dictionary.".Format(memberName));
+		}
+
+		protected override IEnumerable GetEnumerable(object value) => (value as IDictionary).Keys;
+
+	}
+}

--- a/HermaFx.DataAnnotations/ValidateValuesUsingAttribute.cs
+++ b/HermaFx.DataAnnotations/ValidateValuesUsingAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+
+namespace HermaFx.DataAnnotations
+{
+	[AttributeUsage(AttributeTargets.Property)]
+	public class ValidateValuesUsingAttribute : ValidateElementsUsingAttribute
+	{
+		#region .ctor
+
+		public ValidateValuesUsingAttribute(Type metadataType, string propertyName)
+			: base(metadataType, propertyName) { }
+
+		public ValidateValuesUsingAttribute(Type metadataType, string propertyName, string errorMessage)
+			: base(metadataType, propertyName, errorMessage)
+		{
+		}
+
+		#endregion
+
+		protected override void CheckTargetType(object value, string memberName)
+		{
+			if (!(value is IDictionary))
+				throw new ValidationException($"Property {memberName} is not dictionary.".Format(memberName));
+		}
+
+		protected override IEnumerable GetEnumerable(object value) => (value as IDictionary).Values;
+
+	}
+}


### PR DESCRIPTION
Create attribute to validate Dictionary keys and values based on ValidateElementsUsingAttribute

usage sample on tests:

```csharp
public class TestDtoMetadata
{
	[Regex(@"^[a-z]{4,10}$")]
	private string KeyProperty { get; set; }
}

public class TestDto
{
	[ValidateKeysUsing(typeof(TestDtoMetadata), "KeyProperty")]
	public Dictionary<string, string> StringList { get; set; }
}

[Test]
public void BasicTest()
{
	var good = new TestDto()
	{
		StringList = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("good", "dummy") })
	};
	var bad = new TestDto()
	{
		StringList = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("bad", "dummy") })
	};

	ExtendedValidator.EnsureIsValid(good);
	Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(bad));
}

[Test]
public void ValidateElementsMandatoryContext()
{
	var good = new TestDto()
	{
		StringList = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("success", "dummy") })
	};

	var results = new List<ValidationResult>();
	Assert.Throws<ArgumentNullException>(() => Validator.TryValidateObject(good, null, results));
}
```