### PR TITLE
Remove IDictionaryExtensions::GetValueOrDefault(IReadOnlyDictionary<>, ..) methods

### DIFF
--- a/HermaFx.Foundation/RuntimeExtensions/IDictionaryExtensions.cs
+++ b/HermaFx.Foundation/RuntimeExtensions/IDictionaryExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HermaFx
 {
 	public static class IDictionaryExtensions
 	{
-		public static IDictionary<K, V> Clone<K,V>(this IDictionary<K, V> source)
+		public static IDictionary<K, V> Clone<K, V>(this IDictionary<K, V> source)
 		{
 			if (source == null) throw new ArgumentNullException("source");
 
@@ -21,18 +21,6 @@ namespace HermaFx
 		}
 
 		public static V GetValueOrDefault<K, V>(this IDictionary<K, V> source, K key)
-		{
-			return source.GetValueOrDefault(key, default(V));
-		}
-
-		public static V GetValueOrDefault<K, V>(this IReadOnlyDictionary<K, V> source, K key, V @default)
-		{
-			if (source == null) throw new ArgumentNullException("source");
-
-			return source.ContainsKey(key) ? source[key] : @default;
-		}
-
-		public static V GetValueOrDefault<K, V>(this IReadOnlyDictionary<K, V> source, K key)
 		{
 			return source.GetValueOrDefault(key, default(V));
 		}


### PR DESCRIPTION
This two methods are implemented in dotnet

https://github.com/dotnet/runtime/blob/811da242e182f376b4d915ec7abb16c1e852462e/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/CollectionExtensions.cs#L11