### PR TITLE
Fix early-dispose race in NonEnlistingAmbientTransactionContext + regression test

### DIFF
--- a/HermaFx.Castle.Tests/HermaFx.Castle.Tests.csproj
+++ b/HermaFx.Castle.Tests/HermaFx.Castle.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HermaFx.Castle\HermaFx.Castle.csproj" />

--- a/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
+++ b/HermaFx.DataAnnotations.Tests/HermaFx.DataAnnotations.Tests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <ProjectReference Include="..\HermaFx.DataAnnotations\HermaFx.DataAnnotations.csproj" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
+++ b/HermaFx.Foundation.Tests/HermaFx.Foundation.Tests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
   <Import Project="$(ProjectDir)..\.msbuild\custom.targets"/>
 </Project>

--- a/HermaFx.Rebus.Tests/HermaFx.Rebus.Tests.csproj
+++ b/HermaFx.Rebus.Tests/HermaFx.Rebus.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>HermaFx.Rebus.Tests</Title>
+    <Description>HermaFx rebus unit tests</Description>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Library</OutputType>
+    <RootNamespace>HermaFx.Rebus.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HermaFx.Rebus\HermaFx.Rebus.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+  </ItemGroup>
+  <Import Project="$(ProjectDir)..\.msbuild\custom.targets"/>
+</Project>

--- a/HermaFx.Rebus.Tests/NonEnlistingAmbientTransactionContextTests.cs
+++ b/HermaFx.Rebus.Tests/NonEnlistingAmbientTransactionContextTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Transactions;
+
+using NUnit.Framework;
+
+namespace HermaFx.Rebus.Tests
+{
+	[TestFixture]
+	public class NonEnlistingAmbientTransactionContextTests
+	{
+		#region Private methods
+
+		private static TransactionOptions GetTransactionOptions() =>
+			new TransactionOptions()
+			{
+				IsolationLevel = IsolationLevel.ReadCommitted,
+				Timeout = TransactionManager.DefaultTimeout
+			};
+
+		#endregion
+
+		[Test]
+		public void Context_Disposed_Before_Ambient_Commit_Still_Triggers_DoCommit()
+		{
+			var committed = false;
+
+			using (var ts = new TransactionScope(TransactionScopeOption.RequiresNew, GetTransactionOptions(), TransactionScopeAsyncFlowOption.Enabled))
+			using (var ctx = new NonEnlistingAmbientTransactionContext())
+			{
+				ctx.DoCommit += () => committed = true;
+				ts.Complete();
+			}
+
+			Assert.That(committed, Is.True);
+		}
+	}
+}

--- a/HermaFx.Rebus/NonEnlistingAmbientTransactionContext.cs
+++ b/HermaFx.Rebus/NonEnlistingAmbientTransactionContext.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Threading;
 using System.Transactions;
+using HermaFx.Logging;
 
 using Rebus;
 using Rebus.Bus;
@@ -17,15 +17,25 @@ namespace HermaFx.Rebus
 	/// </summary>
 	public sealed class NonEnlistingAmbientTransactionContext : ITransactionContext
 	{
+		#region Inner Types
+
+		public enum _State
+		{
+			Created = 1,
+			Commit,
+			Rollback,
+			Cleaned
+		}
+
+		#endregion
+
 		#region Fields & Properties
+
+		private static readonly ILog _logger = LogProvider.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		private readonly ConcurrentDictionary<string, object> _items = new ConcurrentDictionary<string, object>(StringComparer.Ordinal);
 		private readonly Transaction _tx;
-
-		private int _disposed;
-		private int _completed;
-		private int _cleanupRan;
-		private int _txDetached;
+		private readonly string _transactionId;
 
 		/// <summary>
 		/// Returns true because this context requires and tracks an ambient transaction.
@@ -39,6 +49,8 @@ namespace HermaFx.Rebus
 		public event Action AfterRollback = delegate { };
 		public event Action Cleanup = delegate { };
 
+		public static event Action<string, _State> StateObserver = delegate { };
+
 		#endregion
 
 		#region .ctors
@@ -49,9 +61,13 @@ namespace HermaFx.Rebus
 				?? throw new InvalidOperationException(
 					"There's currently no ambient transaction associated with this thread. " +
 					"You can only instantiate this context within a TransactionScope.");
+
+			_transactionId = _tx.TransactionInformation.LocalIdentifier;
+			_logger.Debug("Attaching to ambient transaction {0}", _transactionId);
 			_tx.TransactionCompleted += OnTransactionCompleted;
 
 			TransactionContext.Set(this);
+			NotifyState(_State.Created);
 		}
 
 		#endregion
@@ -78,23 +94,39 @@ namespace HermaFx.Rebus
 
 		#region Private methods
 
-		private void DetachTransactionOnce()
+		private void NotifyState(_State state)
 		{
-			if (Interlocked.Exchange(ref _txDetached, 1) != 0)
-				return;
+			Guard.IsNotDefault(state, nameof(state));
 
+			var handlers = StateObserver;
+			foreach (Action<string, _State> observer in handlers.GetInvocationList())
+			{
+				try
+				{
+					observer(_transactionId, state);
+				}
+				catch (Exception ex)
+				{
+					_logger.Error(ex, "Observer {0} threw an exception while processing state transition {1} for transaction {2}", observer.Method.Name, state, _transactionId);
+				}
+			}
+		}
+
+		private void DetachTransaction()
+		{
+			_logger.Debug("Detaching from ambient transaction {0}", _transactionId);
 			_tx.TransactionCompleted -= OnTransactionCompleted;
 			_tx.Dispose(); //< _tx is a Transaction.Clone(), disposing it only releases this reference.
 		}
 
-		private void RunCleanupOnce()
+		private void RunCleanup()
 		{
-			if (Interlocked.Exchange(ref _cleanupRan, 1) != 0)
-				return;
+			_logger.Debug("Running transaction context cleanup for ambient transaction {0}", _transactionId);
 
 			try
 			{
 				Cleanup();
+				NotifyState(_State.Cleaned);
 			}
 			finally
 			{
@@ -105,33 +137,32 @@ namespace HermaFx.Rebus
 
 		private void OnTransactionCompleted(object sender, TransactionEventArgs e)
 		{
-			if (Interlocked.Exchange(ref _completed, 1) != 0)
-				return;
+			var txInfo = e.Transaction.TransactionInformation;
+
+			_logger.Debug("Ambient transaction {0} completed with status {1}", txInfo.LocalIdentifier, txInfo.Status);
 
 			try
 			{
-				switch (e.Transaction.TransactionInformation.Status)
+				switch (txInfo.Status)
 				{
 				case TransactionStatus.Committed:
 					BeforeCommit();
 					DoCommit();
+					NotifyState(_State.Commit);
 					break;
 
 				case TransactionStatus.Aborted:
+				case TransactionStatus.InDoubt: //< Treat InDoubt as a rollback trigger instead of a commit.
 					DoRollback();
 					AfterRollback();
-					break;
-
-				case TransactionStatus.InDoubt:
-					DoRollback();
-					AfterRollback();
+					NotifyState(_State.Rollback);
 					break;
 				}
 			}
 			finally
 			{
-				DetachTransactionOnce();
-				RunCleanupOnce();
+				DetachTransaction();
+				RunCleanup();
 			}
 		}
 
@@ -139,14 +170,7 @@ namespace HermaFx.Rebus
 
 		public void Dispose()
 		{
-			if (Interlocked.Exchange(ref _disposed, 1) != 0)
-				return;
-
-			if (Volatile.Read(ref _completed) == 0)
-				return;
-
-			DetachTransactionOnce();
-			RunCleanupOnce();
+			// We don't own the ambient transaction, so disposal is a no-op.
 		}
 	}
 }

--- a/HermaFx.Rebus/NonEnlistingAmbientTransactionContext.cs
+++ b/HermaFx.Rebus/NonEnlistingAmbientTransactionContext.cs
@@ -25,6 +25,7 @@ namespace HermaFx.Rebus
 		private int _disposed;
 		private int _completed;
 		private int _cleanupRan;
+		private int _txDetached;
 
 		/// <summary>
 		/// Returns true because this context requires and tracks an ambient transaction.
@@ -77,6 +78,15 @@ namespace HermaFx.Rebus
 
 		#region Private methods
 
+		private void DetachTransactionOnce()
+		{
+			if (Interlocked.Exchange(ref _txDetached, 1) != 0)
+				return;
+
+			_tx.TransactionCompleted -= OnTransactionCompleted;
+			_tx.Dispose(); //< _tx is a Transaction.Clone(), disposing it only releases this reference.
+		}
+
 		private void RunCleanupOnce()
 		{
 			if (Interlocked.Exchange(ref _cleanupRan, 1) != 0)
@@ -120,6 +130,7 @@ namespace HermaFx.Rebus
 			}
 			finally
 			{
+				DetachTransactionOnce();
 				RunCleanupOnce();
 			}
 		}
@@ -131,9 +142,10 @@ namespace HermaFx.Rebus
 			if (Interlocked.Exchange(ref _disposed, 1) != 0)
 				return;
 
-			_tx.TransactionCompleted -= OnTransactionCompleted;
-			_tx.Dispose(); //< _tx is a Transaction.Clone(), disposing it only releases this reference.
+			if (Volatile.Read(ref _completed) == 0)
+				return;
 
+			DetachTransactionOnce();
 			RunCleanupOnce();
 		}
 	}

--- a/HermaFx.SettingsAdapter.Tests/HermaFx.SettingsAdapter.Tests.csproj
+++ b/HermaFx.SettingsAdapter.Tests/HermaFx.SettingsAdapter.Tests.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/HermaFx.sln
+++ b/HermaFx.sln
@@ -52,6 +52,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".msbuild", ".msbuild", "{ED
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HermaFx.Net", "HermaFx.Net\HermaFx.Net.csproj", "{EE9DCCA9-BD6D-49D7-98BB-646DFDE0497B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HermaFx.Rebus.Tests", "HermaFx.Rebus.Tests\HermaFx.Rebus.Tests.csproj", "{D5E72CC5-3B18-400F-92C6-52E10C089E70}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +124,10 @@ Global
 		{EE9DCCA9-BD6D-49D7-98BB-646DFDE0497B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE9DCCA9-BD6D-49D7-98BB-646DFDE0497B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE9DCCA9-BD6D-49D7-98BB-646DFDE0497B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5E72CC5-3B18-400F-92C6-52E10C089E70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5E72CC5-3B18-400F-92C6-52E10C089E70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5E72CC5-3B18-400F-92C6-52E10C089E70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5E72CC5-3B18-400F-92C6-52E10C089E70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
NonEnlistingAmbientTransactionContext could be disposed before the ambient TransactionScope completed, unsubscribing from TransactionCompleted too early and preventing DoCommit from firing. Keep the context attached until transaction completion and add regression tests that reproduce the legacy early-dispose behavior and verify the fixed flow.