### PR TITLE
Fix null element handling in ValidateElementsUsing for dictionary value validation

### DIFF
--- a/HermaFx.DataAnnotations.Tests/ValidateValuessUsingTests.cs
+++ b/HermaFx.DataAnnotations.Tests/ValidateValuessUsingTests.cs
@@ -15,6 +15,18 @@ namespace HermaFx.DataAnnotations
 			private string ValueProperty { get; set; }
 		}
 
+		public class RequiredValueMetadata
+		{
+			[Required]
+			private string ValueProperty { get; set; }
+		}
+
+		public class RequiredValueAllowEmptyStringsMetadata
+		{
+			[Required(AllowEmptyStrings = true)]
+			private string ValueProperty { get; set; }
+		}
+
 		public class TestDto
 		{
 			[ValidateValuesUsing(typeof(TestDtoMetadata), "ValueProperty")]
@@ -25,6 +37,18 @@ namespace HermaFx.DataAnnotations
 		{
 			[ValidateValuesUsing(typeof(TestDtoMetadata), "ValueProperty")]
 			public TestDto TestProperty { get; set; }
+		}
+
+		public class RequiredValueDto
+		{
+			[ValidateValuesUsing(typeof(RequiredValueMetadata), "ValueProperty")]
+			public Dictionary<string, string> TestProperty { get; set; }
+		}
+
+		public class RequiredValueAllowEmptyStringsDto
+		{
+			[ValidateValuesUsing(typeof(RequiredValueAllowEmptyStringsMetadata), "ValueProperty")]
+			public Dictionary<string, string> TestProperty { get; set; }
 		}
 
 		[Test]
@@ -61,6 +85,55 @@ namespace HermaFx.DataAnnotations
 
 			var results = new List<ValidationResult>();
 			Assert.Throws<ArgumentNullException>(() => Validator.TryValidateObject(good, null, results));
+		}
+
+		[Test]
+		public void ValidateValuesUsing_Null_DictionaryValue_Not_Required_Return_Ok()
+		{
+			var dto = new TestDto()
+			{
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", null) })
+			};
+
+			var results = new List<ValidationResult>();
+
+			ExtendedValidator.EnsureIsValid(dto);
+		}
+
+		[Test]
+		public void ValidateValuesUsing_Null_DictionaryValue_WithRequired_ReturnsValidationError()
+		{
+			var dto = new RequiredValueDto()
+			{
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", null) })
+			};
+
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(dto));
+
+			var dtoEmpty = new RequiredValueDto()
+			{
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", "") })
+			};
+
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(dtoEmpty));
+		}
+
+		[Test]
+		public void ValidateValuesUsing_Null_DictionaryValue_WithRequired_AllowEmptyStrings()
+		{
+			var dto = new RequiredValueAllowEmptyStringsDto()
+			{
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", null) })
+			};
+
+			Assert.Throws<AggregateValidationException>(() => ExtendedValidator.EnsureIsValid(dto));
+
+			var dtoEmpty = new RequiredValueAllowEmptyStringsDto()
+			{
+				TestProperty = new Dictionary<string, string>(new[] { new KeyValuePair<string, string>("dummy", "") })
+			};
+
+			ExtendedValidator.EnsureIsValid(dtoEmpty);
 		}
 
 		[Test]

--- a/HermaFx.DataAnnotations/ValidateElementsUsingAttribute.cs
+++ b/HermaFx.DataAnnotations/ValidateElementsUsingAttribute.cs
@@ -83,52 +83,13 @@ namespace HermaFx.DataAnnotations
 			return member;
 		}
 
-
-		private IEnumerable<ValidationResult> ValidateProperties(object value, ValidationContext context)
+		private static ValidationContext CreateContextFor(object item, ValidationContext context, int idx2)
 		{
-			if (value == null) return Enumerable.Empty<ValidationResult>();
-
-			var type = value.GetType();
-			var results = new List<ValidationResult>();
-
-			// Now go through the properties and find any that are complex enough that they might
-			// have their own validation requirements. Recurse into each value that we find.
-			foreach (var property in type.GetProperties())
+			return new ValidationContext(item, null, context.Items)
 			{
-				// Ignore properties with no getter.
-				if (!property.CanRead)
-					continue;
-
-				// Ignore indexed properties as there is no way to know how to enumerate them on
-				// their own. Classes should implement IEnumberable if they want these accessed
-				// anyway.
-				if (property.GetIndexParameters().Length > 0)
-					continue;
-
-				// Get the value assigned to the property and recurse into it
-				var value2 = property.GetValue(value, null);
-				var reqattr = property.GetCustomAttribute<RequiredAttribute>();
-				var newctx = new ValidationContext(value2 ?? "", context.Items)
-				{
-					DisplayName = context.DisplayName.IfNotNull(x => string.Join(":", x, property.Name)),
-					MemberName = context.MemberName.IfNotNull(x => string.Join(".", x, property.Name))
-				};
-
-				// Let's first evaluate RequiredAttribute..
-				if (reqattr != null)
-				{
-					var attr = property.GetCustomAttribute<RequiredAttribute>();
-					var res = attr.GetValidationResult(value2, newctx);
-					if (res != ValidationResult.Success) results.Add(res);
-				}
-
-				if (value2 != null)
-				{
-					Validator.TryValidateObject(value2, newctx, results);
-				}
-			}
-
-			return results;
+				DisplayName = context.DisplayName.IfNotNull(x => string.Format("{0}[{1}]", x, idx2)),
+				MemberName = context.MemberName.IfNotNull(x => string.Format("{0}[{1}]", x, idx2))
+			};
 		}
 
 		protected override ValidationResult IsValid(object value, ValidationContext context)
@@ -157,13 +118,24 @@ namespace HermaFx.DataAnnotations
 				foreach (var item in valueAsEnumerable)
 				{
 					var idx2 = idx++;
+
+					// RequiredAttribute needs special treatment, as we might need to evaluate it against null (or default) values..
+					var req = member.GetCustomAttribute<RequiredAttribute>();
+					if (req != null)
+					{
+						var tmp = CreateContextFor(item ?? "", context, idx2);
+						var res = req.GetValidationResult(item, tmp);
+						if (res != ValidationResult.Success) results.Add(res);
+					}
+
+					if (item == null) continue;
+
 					var newctx = new ValidationContext(item, null, context.Items)
 					{
 						DisplayName = context.DisplayName.IfNotNull(x => string.Format("{0}[{1}]", x, idx2)),
 						MemberName = context.MemberName.IfNotNull(x => string.Format("{0}[{1}]", x, idx2))
 					};
 					results.AddRange(ValidateClass(item, newctx, attributes));
-					//results.AddRange(ValidateProperties(item, newctx));
 				}
 			}
 


### PR DESCRIPTION
This PR fixes a validation crash in ValidateElementsUsingAttribute when validating enumerable elements that contain null values (e.g., dictionary values in ValidateValuesUsing).  

Previously, a null element could trigger an unhandled ArgumentNullException during ValidationContext creation instead of returning a regular validation result.

What changed
- Updated ValidateElementsUsingAttribute to handle null elements safely during per-item validation.
- Kept validation behavior for non-null elements unchanged.
- Ensured that null values can still be validated by downstream validation attributes (such as [Required]) as proper validation failures, not runtime crashes.
Tests
Added/updated tests in HermaFx.DataAnnotations.Tests to cover:
- Null dictionary values in ValidateValuesUsing scenarios.
- Expected behavior with [Required] metadata: null values now produce validation errors (aggregate validation result), not unhandled exceptions.
- Existing behavior for valid and invalid non-null values remains intact.